### PR TITLE
bug fix in tptp parser

### DIFF
--- a/core/src/main/antlr4/fortress/inputs/FOFTPTP.g4
+++ b/core/src/main/antlr4/fortress/inputs/FOFTPTP.g4
@@ -2,9 +2,11 @@ grammar FOFTPTP;
 
 spec : line+ EOF;
 
-line : 'fof' '(' ID ',' ID ',' fof_formula ')' '.'     # fof_annotated
-     | 'include' '(' SINGLE_STRING ')' '.'             # include
+line : 'fof' '(' name ',' ID ',' fof_formula ')' '.'     # fof_annotated
+     | 'include' '(' SINGLE_QUOTED ')' '.'               # include
      ;                           
+
+name : ID | SINGLE_QUOTED ;
 
 fof_formula : '~' fof_formula                            # not
             | '!' '[' ID (',' ID)* ']' ':' fof_formula   # forall
@@ -16,6 +18,7 @@ fof_formula : '~' fof_formula                            # not
             | term '=' term                              # eq
             | term '!=' term                             # neq
             | ID                                         # prop
+            | DEFINED_PROP                               # defined_prop
             | ID '(' term (',' term)* ')'                # pred
             | '(' fof_formula ')'                        # paren
             ;
@@ -24,11 +27,11 @@ term : ID                          # conVar
      | ID '(' term (',' term)* ')' # apply
      ;
 
-SINGLE_STRING
-    : '\'' ~('\'')+ '\''
-    ;
+SINGLE_QUOTED : '\'' ~('\'')+ '\'' ;
 
 ID : [_a-zA-Z][_a-zA-Z0-9]* ;
+
+DEFINED_PROP : '$true' | '$false' ;
 
 WS : [ \t\r\n] -> skip;
 COMMENT : '%'   ~('\r' | '\n')*  ('\r'? '\n')? -> skip;

--- a/core/src/main/scala/fortress/inputs/TptpToFortress.java
+++ b/core/src/main/scala/fortress/inputs/TptpToFortress.java
@@ -82,7 +82,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
     @Override
     public Term visitFof_annotated(FOFTPTPParser.Fof_annotatedContext ctx) {
         Term f = (Term) visit(ctx.fof_formula());
-        if (ctx.ID(1).getText().equals("conjecture")) {
+        if (ctx.ID().getText().equals("conjecture")) {
             formulas.add(Term.mkNot(f));
         }
         else {
@@ -93,7 +93,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitInclude(FOFTPTPParser.IncludeContext ctx) {
-        String inputFilePath = ctx.SINGLE_STRING().getText();
+        String inputFilePath = ctx.SINGLE_QUOTED().getText();
         // remove the surrounding single quotes
         inputFilePath = inputFilePath.substring(1, inputFilePath.length() - 1);
         // there is a danger here with infinite includes
@@ -206,6 +206,16 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
         Var v = Term.mkVar(name);
         primePropositions.add(v);
         return v;
+    }
+
+    @Override
+    public Term visitDefined_prop(FOFTPTPParser.Defined_propContext ctx) {
+        String name = ctx.DEFINED_PROP().getText();
+        if(name.equals("$true"))
+            return Term.mkTop();
+        else if(name.equals("$false"))
+            return Term.mkBottom();
+        return null;
     }
 
     @Override

--- a/core/src/test/scala/inputs/TptpParserTest.scala
+++ b/core/src/test/scala/inputs/TptpParserTest.scala
@@ -1,4 +1,4 @@
-import java.io.{File, FileInputStream, FileOutputStream}
+import java.io.{ByteArrayInputStream, File, FileInputStream, FileOutputStream, StringBufferInputStream}
 import fortress.inputs._
 import fortress.modelfind._
 import fortress.msfol._
@@ -130,4 +130,26 @@ class TptpParserTest extends UnitSuite {
 
         resultTheory should be(expectedTheory)
     }
+
+    test("defined proposition example") {
+        val tptp_content = "fof('defined-prop',axiom,( " +
+          "( a = a => $true ) & " +
+          "( $false  => a = a))" +
+          ")."
+        val inputStream = new ByteArrayInputStream(tptp_content.getBytes())
+
+        val resultTheory = (new TptpFofParser).parse(inputStream).getOrElse()
+        val universeSort = Sort.mkSortConst("_UNIV")
+
+        val a = Var("a")
+        val axiom1 = And(Implication(Eq(a,a),Top), Implication(Bottom,Eq(a,a)))
+
+        val expectedTheory = Theory.empty
+          .withSort(universeSort)
+          .withConstant(a.of(universeSort))
+          .withAxiom(axiom1)
+
+        resultTheory should be (expectedTheory)
+    }
+
 }


### PR DESCRIPTION
1. <fof_annotated> ::= fof(<name>,<formula_role>,<fof_formula><annotations>).      
    <name> might accept a single quoted string
2. $true and $false are defined proposition.