### PR TITLE
Added suffix aa to tptp var and function names

### DIFF
--- a/DevelopersGuide.md
+++ b/DevelopersGuide.md
@@ -197,6 +197,7 @@ Hierarchy:
     - SmtLibParser: Is an instances of a TheoryParser for SMT-LIB; relies on SmtLibVisitor to convert the parsed data into a theory. Returns a theory.  Also includes info and logic from the SMT-LIB parser, but these are not used further in Fortress. SmtLibVisitor has visitors over the antlr grammar for SMT-LIB.  Maps Bool and Int sorts to Fortress' built-in Bool and Int sorts.  Theory is built directly during the visitor.  Let statements (parallel substitution) are substituted to create terms.  Attributes in SMT-LIB are ignored. Ignores check-sat commands.  Not yet supported: Right/Left bitshift, unsigned div/rem, and, or, not, concat bit operations; abs val for ints.  
     @Joe: it would be good to fix the SmtLib files/parsers to use the same naming conventions - one is called a Visitor and one is called ToFortress.
     @Joe - the TPTP parser does not appear to StopAtFirstErrorStrategy or StopAtFirstErrorSmtLibLexer but the SMT-LIB strategy does??
+- Currently, we are not supporting the following operators when parsing tptp: infix <~> for non-equivalence(XOR),  infix ~| for negated disjunction (NOR), infix ~& for negated conjunction (NAND).
 
 ## operations 
 Operations on terms are wrapped up in TermOps class.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Example usage:
 ./fortressdebug-x.y.z/bin/fortressdebug --timeout 60 --mode count -S A=3 B=2 --version v0 function.smt2
 ```
 
+You can increase the JVM stack size by setting option "-J-Xss<size>", for example, "-J-Xss8m" sets the max stack size to 8 MB. You might want to increase stack size, because the antlr parser causes stack overflow errors when parsing large smt2 and tptp files.
+
 ## Building Fortress
 The following are necessary to build Fortress:
 * Java 10 or higher

--- a/core/src/main/antlr4/fortress/inputs/FOFTPTP.g4
+++ b/core/src/main/antlr4/fortress/inputs/FOFTPTP.g4
@@ -6,7 +6,8 @@ line : 'fof' '(' name ',' ID ',' fof_formula ')' '.'     # fof_annotated
      | 'include' '(' SINGLE_QUOTED ')' '.'               # include
      ;                           
 
-name : ID | SINGLE_QUOTED ;
+// Currently, we are not supporting operators:
+// infix <~> for non-equivalence(XOR),  infix ~| for negated disjunction (NOR), infix ~& for negated conjunction (NAND)
 
 fof_formula : '~' fof_formula                            # not
             | '!' '[' ID (',' ID)* ']' ':' fof_formula   # forall
@@ -22,6 +23,8 @@ fof_formula : '~' fof_formula                            # not
             | ID '(' term (',' term)* ')'                # pred
             | '(' fof_formula ')'                        # paren
             ;
+
+name : ID | SINGLE_QUOTED ;
 
 term : ID                          # conVar
      | ID '(' term (',' term)* ')' # apply

--- a/core/src/main/scala/fortress/inputs/TptpToFortress.java
+++ b/core/src/main/scala/fortress/inputs/TptpToFortress.java
@@ -140,7 +140,8 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
     public Term visitForall(FOFTPTPParser.ForallContext ctx) {
         List<AnnotatedVar> variables = new ArrayList<>();
         for(TerminalNode variableNode: ctx.ID()) {
-            String name = variableNode.getText();
+            // add suffix “aa” to avoid illegal variable name
+            String name = variableNode.getText() + "aa";
             variables.add(Term.mkVar(name).of(universeSort));
         }
         Term body = (Term) visit(ctx.fof_formula());
@@ -151,7 +152,8 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
     public Term visitExists(FOFTPTPParser.ExistsContext ctx) {
         List<AnnotatedVar> variables = new ArrayList<>();
         for (TerminalNode variableNode: ctx.ID()) {
-            String name = variableNode.getText();
+            // add suffix “aa” to avoid illegal variable name
+            String name = variableNode.getText() + "aa";
             variables.add(Term.mkVar(name).of(universeSort));
         }
         Term body = (Term) visit(ctx.fof_formula());
@@ -202,7 +204,8 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitProp(FOFTPTPParser.PropContext ctx) {
-        String name = ctx.ID().getText();
+        // add suffix “aa” to avoid illegal variable name
+        String name = ctx.ID().getText() + "aa";
         Var v = Term.mkVar(name);
         primePropositions.add(v);
         return v;
@@ -220,7 +223,8 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitPred(FOFTPTPParser.PredContext ctx) {
-        String name = ctx.ID().getText();
+        // add suffix “aa” to avoid illegal function name
+        String name = ctx.ID().getText() + "aa";
         int numArgs = ctx.term().size();
 
         List<Sort> argSorts = new ArrayList<>();
@@ -245,13 +249,15 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitConVar(FOFTPTPParser.ConVarContext ctx) {
-        String name = ctx.ID().getText();
+        // add suffix “aa” to avoid illegal variable name
+        String name = ctx.ID().getText() + "aa";
         return Term.mkVar(name);
     }
 
     @Override
     public Term visitApply(FOFTPTPParser.ApplyContext ctx) {
-        String name = ctx.ID().getText();
+        // add suffix “aa” to avoid illegal function name
+        String name = ctx.ID().getText() + "aa";
         int numArgs = ctx.term().size();
         
         List<Sort> argSorts = new ArrayList<>();

--- a/core/src/test/scala/inputs/TptpParserTest.scala
+++ b/core/src/test/scala/inputs/TptpParserTest.scala
@@ -9,7 +9,7 @@ import scala.reflect.io.Directory
 
 class TptpParserTest extends UnitSuite {
 
-    def createFileInTempDir(src: File, dest: File) : Unit = {
+    def createFileInTempDir(src: File, dest: File): Unit = {
         dest.getParentFile().mkdirs()
         dest.createNewFile()
         new FileOutputStream(dest).getChannel() transferFrom(new FileInputStream(src).getChannel(), 0, Long.MaxValue)
@@ -19,44 +19,44 @@ class TptpParserTest extends UnitSuite {
         val classLoader = getClass.getClassLoader
         val file = new File(classLoader.getResource("abelian.p").getFile)
         val fileStream = new FileInputStream(file)
-        
+
         val resultTheory = (new TptpFofParser).parse(fileStream).getOrElse()
         val universeSort = Sort.mkSortConst("_UNIV")
-        
-        val A = Var("A")
-        val B = Var("B")
-        val C = Var("C")
-        val e = Var("e")
-        val f = FuncDecl.mkFuncDecl("f", universeSort, universeSort, universeSort)
-        
+
+        val A = Var("Aaa")
+        val B = Var("Baa")
+        val C = Var("Caa")
+        val e = Var("eaa")
+        val f = FuncDecl.mkFuncDecl("faa", universeSort, universeSort, universeSort)
+
         val associative = Forall(Seq(A.of(universeSort), B.of(universeSort), C.of(universeSort)),
             Eq(
-                App("f", App("f", A, B), C),
-                App("f", A, App("f", B, C))))
-        
+                App("faa", App("faa", A, B), C),
+                App("faa", A, App("faa", B, C))))
+
         val identity = Forall(A.of(universeSort),
             And(
-                Eq(App("f", A, e), A),
-                Eq(App("f", e, A), A)))
-        
-        val inverse = Forall(A.of(universeSort), Exists(B.of(universeSort), 
+                Eq(App("faa", A, e), A),
+                Eq(App("faa", e, A), A)))
+
+        val inverse = Forall(A.of(universeSort), Exists(B.of(universeSort),
             And(
-                Eq(App("f", A, B), e),
-                Eq(App("f", B, A), e))))
-        
+                Eq(App("faa", A, B), e),
+                Eq(App("faa", B, A), e))))
+
         val notAbelian = Not(Forall(Seq(A.of(universeSort), B.of(universeSort)),
-            Eq(App("f", A, B), App("f", B, A))))
-        
+            Eq(App("faa", A, B), App("faa", B, A))))
+
         val expectedTheory = Theory.empty
-            .withSort(universeSort)
-            .withConstant(e.of(universeSort))
-            .withFunctionDeclaration(f)
-            .withAxiom(associative)
-            .withAxiom(identity)
-            .withAxiom(inverse)
-            .withAxiom(notAbelian)
-        
-        resultTheory should be (expectedTheory)
+          .withSort(universeSort)
+          .withConstant(e.of(universeSort))
+          .withFunctionDeclaration(f)
+          .withAxiom(associative)
+          .withAxiom(identity)
+          .withAxiom(inverse)
+          .withAxiom(notAbelian)
+
+        resultTheory should be(expectedTheory)
     }
 
     test("include example ALG212") {
@@ -73,7 +73,7 @@ class TptpParserTest extends UnitSuite {
 
         // Clean up the temporary directory
         val directory = new Directory(tempDir.toFile)
-        directory.deleteRecursively() should be (true)
+        directory.deleteRecursively() should be(true)
 
         val file2 = new File(classLoader.getResource("ALG212+1_imported.p").getFile)
         val fileStream2 = new FileInputStream(file2)
@@ -96,7 +96,7 @@ class TptpParserTest extends UnitSuite {
 
         // Clean up the temporary directory
         val directory = new Directory(tempDir.toFile)
-        directory.deleteRecursively() should be (true)
+        directory.deleteRecursively() should be(true)
 
         val file2 = new File(classLoader.getResource("GEO091+1_imported.p").getFile)
         val fileStream2 = new FileInputStream(file2)
@@ -122,7 +122,7 @@ class TptpParserTest extends UnitSuite {
 
         // Clean up the temporary directory
         val directory = new Directory(tempDir.toFile)
-        directory.deleteRecursively() should be (true)
+        directory.deleteRecursively() should be(true)
 
         val file2 = new File(classLoader.getResource("MED009+1_imported.p").getFile)
         val fileStream2 = new FileInputStream(file2)
@@ -141,15 +141,15 @@ class TptpParserTest extends UnitSuite {
         val resultTheory = (new TptpFofParser).parse(inputStream).getOrElse()
         val universeSort = Sort.mkSortConst("_UNIV")
 
-        val a = Var("a")
-        val axiom1 = And(Implication(Eq(a,a),Top), Implication(Bottom,Eq(a,a)))
+        val a = Var("a" + "aa")
+        val axiom1 = And(Implication(Eq(a, a), Top), Implication(Bottom, Eq(a, a)))
 
         val expectedTheory = Theory.empty
           .withSort(universeSort)
           .withConstant(a.of(universeSort))
           .withAxiom(axiom1)
 
-        resultTheory should be (expectedTheory)
+        resultTheory should be(expectedTheory)
     }
 
 }


### PR DESCRIPTION
1. Some tptp files uses "true", "false" as variable names, "if", "exists" as function names, which are illegal in fortress. We added suffix "aa" to all function and variable names in order to parse those tptp files.
2. Add some documentation about operators in tptp grammar we are not supporting: infix <~> for non-equivalence(XOR),  infix ~| for negated disjunction (NOR), infix ~& for negated conjunction (NAND).
3. Add to the readme how to increase stack size.