### PR TITLE
Added new symmetry breaking transformer with disjuncts limit and most used order

### DIFF
--- a/core/src/main/scala/fortress/modelfind/FortressModelFinders.scala
+++ b/core/src/main/scala/fortress/modelfind/FortressModelFinders.scala
@@ -42,6 +42,18 @@ class FortressTHREE_SI(solverInterface: SolverInterface) extends CompilationMode
     override def createCompiler(integerSemantics: IntegerSemantics): LogicCompiler = new FortressTHREECompiler_SI(integerSemantics)
 }
 
+class FortressFOUR(solverInterface: SolverInterface) extends CompilationModelFinder(solverInterface) {
+    def this() = this(Z3IncCliInterface)
+
+    override def createCompiler(integerSemantics: IntegerSemantics): LogicCompiler = new FortressFOURCompiler(integerSemantics)
+}
+
+class FortressFOUR_SI(solverInterface: SolverInterface) extends CompilationModelFinder(solverInterface) {
+    def this() = this(Z3IncCliInterface)
+
+    override def createCompiler(integerSemantics: IntegerSemantics): LogicCompiler = new FortressFOURCompiler_SI(integerSemantics)
+}
+
 class FortressUnbounded(solverInterface: SolverInterface) extends CompilationModelFinder(solverInterface) {
     def this() = this(Z3IncCliInterface)
 

--- a/core/src/main/scala/fortress/operations/TermMetrics.scala
+++ b/core/src/main/scala/fortress/operations/TermMetrics.scala
@@ -1,63 +1,100 @@
 package fortress.operations
 
 import fortress.msfol._
+
+import scala.collection.mutable
 import scala.math.max
 
 object TermMetrics {
-  // Returns depth of quantification of a term
-  def depthQuantification(term: Term): Int = term match {
-    case Forall(vars, body) => depthQuantification(body) + vars.length
-    case Exists(vars, body) => depthQuantification(body) + vars.length
-    case AndList(args) => args.map(depthQuantification).max
-    case OrList(args) => args.map(depthQuantification).max
-    case Not(body) => depthQuantification(body)
-    case Distinct(args) => args.map(depthQuantification).max
-    case Implication(p, q) => max(depthQuantification(p), depthQuantification(q))
-    case Iff(p, q) => max(depthQuantification(p), depthQuantification(q))
-    case Eq(p, q) => max(depthQuantification(p), depthQuantification(q))
-    case App(_, args) => args.map(depthQuantification).max
-    case BuiltinApp(_, args) => args.map(depthQuantification).max
-    case Closure(_, args, _, _) => args.map(depthQuantification).max
-    case ReflexiveClosure(_, args, _, _) => args.map(depthQuantification).max
-    case Top | Bottom | Var(_) | EnumValue(_) | DomainElement(_, _) | IntegerLiteral(_) | BitVectorLiteral(_, _) => 0
-    case IfThenElse(condition, ifTrue, ifFalse) => (List(condition, ifTrue, ifFalse) map depthQuantification).max
-  }
+    // Returns depth of quantification of a term
+    def depthQuantification(term: Term): Int = term match {
+        case Forall(vars, body) => depthQuantification(body) + vars.length
+        case Exists(vars, body) => depthQuantification(body) + vars.length
+        case AndList(args) => args.map(depthQuantification).max
+        case OrList(args) => args.map(depthQuantification).max
+        case Not(body) => depthQuantification(body)
+        case Distinct(args) => args.map(depthQuantification).max
+        case Implication(p, q) => max(depthQuantification(p), depthQuantification(q))
+        case Iff(p, q) => max(depthQuantification(p), depthQuantification(q))
+        case Eq(p, q) => max(depthQuantification(p), depthQuantification(q))
+        case App(_, args) => args.map(depthQuantification).max
+        case BuiltinApp(_, args) => args.map(depthQuantification).max
+        case Closure(_, args, _, _) => args.map(depthQuantification).max
+        case ReflexiveClosure(_, args, _, _) => args.map(depthQuantification).max
+        case Top | Bottom | Var(_) | EnumValue(_) | DomainElement(_, _) | IntegerLiteral(_) | BitVectorLiteral(_, _) => 0
+        case IfThenElse(condition, ifTrue, ifFalse) => (List(condition, ifTrue, ifFalse) map depthQuantification).max
+    }
 
-  // Returns depth of nested functions of a term
-  def depthNestedFunc(term: Term): Int = term match {
-    case Forall(_, body) => depthNestedFunc(body)
-    case Exists(_, body) => depthNestedFunc(body)
-    case AndList(args) => args.map(depthNestedFunc).max
-    case OrList(args) => args.map(depthNestedFunc).max
-    case Not(body) => depthNestedFunc(body)
-    case Distinct(args) => args.map(depthNestedFunc).max
-    case Implication(p, q) => max(depthNestedFunc(p), depthNestedFunc(q))
-    case Iff(p, q) => max(depthNestedFunc(p), depthNestedFunc(q))
-    case Eq(p, q) => max(depthNestedFunc(p), depthNestedFunc(q))
-    case App(_, args) => args.map(depthNestedFunc).max + 1
-    case BuiltinApp(_, args) => args.map(depthNestedFunc).max + 1
-    case Closure(_, args, _, _) => args.map(depthNestedFunc).max + 1
-    case ReflexiveClosure(_, args, _, _) => args.map(depthNestedFunc).max + 1
-    case Top | Bottom | Var(_) | EnumValue(_) | DomainElement(_, _) | IntegerLiteral(_) | BitVectorLiteral(_, _) => 0
-    case IfThenElse(condition, ifTrue, ifFalse) => (List(condition, ifTrue, ifFalse) map depthNestedFunc).max
-  }
+    // Returns depth of nested functions of a term
+    def depthNestedFunc(term: Term): Int = term match {
+        case Forall(_, body) => depthNestedFunc(body)
+        case Exists(_, body) => depthNestedFunc(body)
+        case AndList(args) => args.map(depthNestedFunc).max
+        case OrList(args) => args.map(depthNestedFunc).max
+        case Not(body) => depthNestedFunc(body)
+        case Distinct(args) => args.map(depthNestedFunc).max
+        case Implication(p, q) => max(depthNestedFunc(p), depthNestedFunc(q))
+        case Iff(p, q) => max(depthNestedFunc(p), depthNestedFunc(q))
+        case Eq(p, q) => max(depthNestedFunc(p), depthNestedFunc(q))
+        case App(_, args) => args.map(depthNestedFunc).max + 1
+        case BuiltinApp(_, args) => args.map(depthNestedFunc).max + 1
+        case Closure(_, args, _, _) => args.map(depthNestedFunc).max + 1
+        case ReflexiveClosure(_, args, _, _) => args.map(depthNestedFunc).max + 1
+        case Top | Bottom | Var(_) | EnumValue(_) | DomainElement(_, _) | IntegerLiteral(_) | BitVectorLiteral(_, _) => 0
+        case IfThenElse(condition, ifTrue, ifFalse) => (List(condition, ifTrue, ifFalse) map depthNestedFunc).max
+    }
 
-  // Returns the number of nodes in a term
-  def termCount(term: Term): Int = term match {
-    case Forall(_, body) => termCount(body) + 1
-    case Exists(_, body) => termCount(body) + 1
-    case AndList(args) => args.map(termCount).sum + 1
-    case OrList(args) => args.map(termCount).sum + 1
-    case Not(body) => termCount(body) + 1
-    case Distinct(args) => args.map(termCount).sum + 1
-    case Implication(p, q) => termCount(p) + termCount(q) + 1
-    case Iff(p, q) => termCount(p) + termCount(q) + 1
-    case Eq(p, q) => termCount(p) + termCount(q) + 1
-    case App(_, args) => args.map(termCount).sum + 1
-    case BuiltinApp(_, args) => args.map(termCount).sum + 1
-    case Closure(_, args, _, _) => args.map(termCount).sum + 1
-    case ReflexiveClosure(_, args, _, _) => args.map(termCount).sum + 1
-    case Top | Bottom | Var(_) | EnumValue(_) | DomainElement(_, _) | IntegerLiteral(_) | BitVectorLiteral(_, _) => 1
-    case IfThenElse(condition, ifTrue, ifFalse) => (List(condition, ifTrue, ifFalse) map termCount).sum + 1
-  }
+    // Returns the number of nodes in a term
+    def termCount(term: Term): Int = term match {
+        case Forall(_, body) => termCount(body) + 1
+        case Exists(_, body) => termCount(body) + 1
+        case AndList(args) => args.map(termCount).sum + 1
+        case OrList(args) => args.map(termCount).sum + 1
+        case Not(body) => termCount(body) + 1
+        case Distinct(args) => args.map(termCount).sum + 1
+        case Implication(p, q) => termCount(p) + termCount(q) + 1
+        case Iff(p, q) => termCount(p) + termCount(q) + 1
+        case Eq(p, q) => termCount(p) + termCount(q) + 1
+        case App(_, args) => args.map(termCount).sum + 1
+        case BuiltinApp(_, args) => args.map(termCount).sum + 1
+        case Closure(_, args, _, _) => args.map(termCount).sum + 1
+        case ReflexiveClosure(_, args, _, _) => args.map(termCount).sum + 1
+        case Top | Bottom | Var(_) | EnumValue(_) | DomainElement(_, _) | IntegerLiteral(_) | BitVectorLiteral(_, _) => 1
+        case IfThenElse(condition, ifTrue, ifFalse) => (List(condition, ifTrue, ifFalse) map termCount).sum + 1
+    }
+
+    // Returns the number of nodes in a term
+    def declarationCountMap(term: Term, profilingInfo: mutable.Map[Declaration, Int]): Unit = term match {
+        case Forall(_, body) => declarationCountMap(body, profilingInfo)
+        case Exists(_, body) => declarationCountMap(body, profilingInfo)
+        case AndList(args) => args.foreach(arg => declarationCountMap(arg, profilingInfo))
+        case OrList(args) => args.foreach(arg => declarationCountMap(arg, profilingInfo))
+        case Not(body) => declarationCountMap(body, profilingInfo)
+        case Distinct(args) => args.foreach(arg => declarationCountMap(arg, profilingInfo))
+        case Implication(p, q) =>
+            declarationCountMap(p, profilingInfo)
+            declarationCountMap(q, profilingInfo)
+        case Iff(p, q) =>
+            declarationCountMap(p, profilingInfo)
+            declarationCountMap(q, profilingInfo)
+        case Eq(p, q) =>
+            declarationCountMap(p, profilingInfo)
+            declarationCountMap(q, profilingInfo)
+        case App(funcName, args) =>
+            val funcDecl = profilingInfo.keySet.filter(pred => pred.isInstanceOf[FuncDecl] && pred.asInstanceOf[FuncDecl].name.equals(funcName)).head
+            profilingInfo(funcDecl) = profilingInfo(funcDecl) + 1
+            args.foreach(arg => declarationCountMap(arg, profilingInfo))
+        case BuiltinApp(_, args) => args.foreach(arg => declarationCountMap(arg, profilingInfo))
+        case Closure(_, args, _, _) => args.foreach(arg => declarationCountMap(arg, profilingInfo))
+        case ReflexiveClosure(_, args, _, _) => args.foreach(arg => declarationCountMap(arg, profilingInfo))
+        case Var(name) =>
+            val annotatedVar = profilingInfo.keySet.filter(pred => pred.isInstanceOf[AnnotatedVar] && pred.asInstanceOf[AnnotatedVar].name.equals(name))
+            // if it is a constant and can be found in the map keys
+            if (annotatedVar.size == 1) {
+                val annotatedVarDecl = annotatedVar.head
+                profilingInfo(annotatedVarDecl) = profilingInfo(annotatedVarDecl) + 1
+            }
+        case Top | Bottom | EnumValue(_) | DomainElement(_, _) | IntegerLiteral(_) | BitVectorLiteral(_, _) => ()
+        case IfThenElse(condition, ifTrue, ifFalse) => List(condition, ifTrue, ifFalse).foreach(arg => declarationCountMap(arg, profilingInfo))
+    }
 }

--- a/core/src/main/scala/fortress/operations/TheoryOps.scala
+++ b/core/src/main/scala/fortress/operations/TheoryOps.scala
@@ -2,12 +2,15 @@ package fortress.operations
 
 import fortress.msfol._
 import fortress.data._
+
 import scala.language.implicitConversions
 import fortress.interpretation._
 import fortress.operations.TermMetrics._
 import fortress.sortinference._
 
-case class TheoryOps private (theory: Theory) {
+import scala.collection.mutable
+
+case class TheoryOps private(theory: Theory) {
     def mapAxioms(f: Term => Term) = Theory(theory.signature, theory.axioms map f)
 
     def verifyInterpretation(interpretation: Interpretation): Boolean =
@@ -76,6 +79,14 @@ case class TheoryOps private (theory: Theory) {
     // Returns whether sort inference found any new sorts
     def newSortsInferred: Boolean = {
         inferSortsCount > 0
+    }
+
+    // Returns whether sort inference found any new sorts
+    def mostUsedDeclarations: Map[Declaration, Int] = {
+        val helper = (r: mutable.Map[Declaration, Int], i: Declaration) => r + (i -> 0)
+        val profilingInfo = (theory.constants ++ theory.functionDeclarations).foldLeft(mutable.Map.empty[Declaration, Int])(helper)
+        theory.axioms.foreach(axiom => TermMetrics.declarationCountMap(axiom, profilingInfo))
+        profilingInfo.toMap
     }
 }
 

--- a/core/src/main/scala/fortress/symmetry/RemainingIdentifiersTracker.scala
+++ b/core/src/main/scala/fortress/symmetry/RemainingIdentifiersTracker.scala
@@ -1,0 +1,38 @@
+package fortress.symmetry
+
+import fortress.msfol._
+
+import scala.collection.mutable
+
+/** Tracks the remaining constants, functions and predicates that we haven't
+  * added any symmetry breaking constraints for
+  */
+class RemainingIdentifiersTracker private(
+                                           remainingConsts: mutable.Set[AnnotatedVar],
+                                           remainingFps: mutable.Set[FuncDecl]
+                                         ) {
+
+    val remainingConstants: mutable.Set[AnnotatedVar] = remainingConsts
+    val remainingFuncDecls: mutable.Set[FuncDecl] = remainingFps
+
+    // Marks constants as used
+    def markUsedConstants(consts: AnnotatedVar*): Unit = {
+        for (con <- consts) {
+            remainingConstants.remove(con)
+        }
+    }
+
+    // Marks constants as used
+    def markUsedFuncDecls(funcDecls: FuncDecl*): Unit = {
+        for (funcDecl <- funcDecls) {
+            remainingFuncDecls.remove(funcDecl)
+        }
+    }
+}
+
+
+object RemainingIdentifiersTracker {
+    def create(remainingConstants: Set[AnnotatedVar], remainingFuncDecls: Set[FuncDecl]): RemainingIdentifiersTracker = {
+        new RemainingIdentifiersTracker(mutable.Set(remainingConstants.toSeq: _*), mutable.Set(remainingFuncDecls.toSeq: _*))
+    }
+}

--- a/core/src/main/scala/fortress/symmetry/SelectionHeuristicWithConstants.scala
+++ b/core/src/main/scala/fortress/symmetry/SelectionHeuristicWithConstants.scala
@@ -1,0 +1,86 @@
+package fortress.symmetry
+
+import fortress.msfol._
+import fortress.util.Errors
+
+
+trait SelectionHeuristicWithConstantsFactory {
+    def create(stalenessTracker: StalenessTracker, remainingTracker: RemainingIdentifiersTracker): SelectionHeuristicWithConstants
+
+    def name: String
+}
+
+abstract class SelectionHeuristicWithConstants(stalenessTrackerParam: StalenessTracker, remainingTrackerParam: RemainingIdentifiersTracker) {
+
+    protected val stalenessTracker: StalenessTracker = stalenessTrackerParam
+    protected val remainingTracker: RemainingIdentifiersTracker = remainingTrackerParam
+
+    def name: String
+
+    // Whether it is done in a preplanned order
+    def isPreplannedOrder: Boolean
+
+    // Select the next sequence of constants, or one function/predicate
+    def nextSelection(): Option[Either[Seq[AnnotatedVar], FuncDecl]]
+}
+
+class LowArityFirstAndMostUsedOrder(stalenessTrackerParam: StalenessTracker, remainingTrackerParam: RemainingIdentifiersTracker)
+  extends SelectionHeuristicWithConstants(stalenessTrackerParam: StalenessTracker, remainingTrackerParam: RemainingIdentifiersTracker) {
+
+    override def name = "Low Arity First, Then Most Used"
+
+    override def isPreplannedOrder: Boolean = true
+
+    var preplannedOrder: Seq[Declaration] = Seq.empty
+
+    // We need profiling info to determine the preplanned order
+    def prepossess(profilingInfo: Map[Declaration, Int]): Unit = {
+        // Comparison operation for constants to determine which order to
+        // perform symmetry breaking
+        def consLessThan(c1: AnnotatedVar, c2: AnnotatedVar): Boolean = {
+            // Most used first
+            Errors.Internal.precondition(profilingInfo.contains(c1) && profilingInfo.contains(c2),
+                "Constants " + c1.name + " or " + c1.name + " cannot be found in the profiling info")
+            profilingInfo(c1) > profilingInfo(c2)
+        }
+
+        // Comparison operation for functions/predicates to determine which order
+        // to perform symmetry breaking
+        def fnLessThan(f1: FuncDecl, f2: FuncDecl): Boolean = {
+            // Lowest arity, then most used
+            if (f1.arity < f2.arity) true
+            else if (f1.arity > f2.arity) false
+            else {
+                Errors.Internal.precondition(profilingInfo.contains(f1) && profilingInfo.contains(f2),
+                    "Function declarations " + f1.name + " or " + f2.name + " cannot be found in the profiling info")
+                profilingInfo(f1) > profilingInfo(f2)
+            }
+        }
+
+        preplannedOrder = (remainingTracker.remainingConstants.toSeq sortWith consLessThan) ++
+          (remainingTracker.remainingFuncDecls.toSeq sortWith fnLessThan)
+    }
+
+    override def nextSelection(): Option[Either[Seq[AnnotatedVar], FuncDecl]] = {
+        if (preplannedOrder.nonEmpty) {
+            preplannedOrder.head match {
+                case decl: FuncDecl =>
+                    // Return the first function or predicate
+                    preplannedOrder = preplannedOrder.drop(1)
+                    return Some(Right(decl))
+                case _: AnnotatedVar =>
+                    // Return the longest sequence of constants at the beginning of the preplanned order
+                    val listOfConstants = preplannedOrder.takeWhile(_.isInstanceOf[AnnotatedVar]).toSeq
+                    preplannedOrder = preplannedOrder.drop(listOfConstants.size)
+                    return Some(Left(listOfConstants.map(_.asInstanceOf[AnnotatedVar])))
+            }
+        }
+        None
+    }
+}
+
+object LowArityFirstAndMostUsedOrderFactory extends SelectionHeuristicWithConstantsFactory {
+    override def name = "Low Arity First, Then Most Used"
+
+    def create(stalenessTracker: StalenessTracker, remainingTracker: RemainingIdentifiersTracker): SelectionHeuristicWithConstants = new LowArityFirstAndMostUsedOrder(stalenessTracker, remainingTracker)
+}

--- a/core/src/main/scala/fortress/symmetry/SymmetryBreakerDL.scala
+++ b/core/src/main/scala/fortress/symmetry/SymmetryBreakerDL.scala
@@ -1,0 +1,148 @@
+package fortress.symmetry
+
+import fortress.msfol._
+import fortress.operations.TermOps._
+
+import scala.collection.mutable
+
+trait SymmetryBreakerFactoryDL {
+    def create(theory: Theory, stalenessTracker: StalenessTracker, remainingTracker: RemainingIdentifiersTracker): SymmetryBreakerDL
+}
+
+abstract class SymmetryBreakerDL(
+                                  theory: Theory,
+                                  stalenessTrackerParam: StalenessTracker,
+                                  remainingTrackerParam: RemainingIdentifiersTracker,
+                                  disjunctsLimitParam: Option[Int] = None
+                                ) {
+
+    protected val stalenessTracker: StalenessTracker = stalenessTrackerParam
+    protected val remainingTracker: RemainingIdentifiersTracker = remainingTrackerParam
+    protected val disjunctsLimit: Option[Int] = disjunctsLimitParam
+
+    // Accumulates the symmetry breaking constraints
+    protected val newConstraints = new mutable.ListBuffer[Term]
+    protected val newRangeRestrictions = new mutable.ListBuffer[RangeRestriction]
+    protected val newDeclarations = new mutable.ListBuffer[FuncDecl]
+
+    // Perform symmetry breaking on constants, one sort by another
+    final def breakConstants(constantsToBreak: Set[AnnotatedVar]): Unit = {
+        for (sort <- theory.sorts if !sort.isBuiltin && stalenessTracker.state.existsFreshValue(sort)) {
+            breakConstants(sort, constantsToBreak.filter(_.sort == sort).toIndexedSeq)
+        }
+    }
+
+    // Perform symmetry breaking on constants, one sort by another(preserve the order)
+    def breakListOfConstants(constantsToBreak: IndexedSeq[AnnotatedVar]): Unit = {
+        val constantsGroupedBySort = constantsToBreak.groupBy(_.sort)
+        for ((sort, constants) <- constantsGroupedBySort if !sort.isBuiltin && stalenessTracker.state.existsFreshValue(sort)) {
+            breakConstants(sort, constants)
+        }
+    }
+
+    // Perform symmetry breaking on constants of the input sort.
+    protected def breakConstants(sort: Sort, constants: IndexedSeq[AnnotatedVar]): Unit
+
+    def breakFunction(f: FuncDecl): Unit
+
+    def breakPredicate(P: FuncDecl): Unit
+
+    def constraints: Seq[Term] = newConstraints.toList
+
+    def rangeRestrictions: Seq[RangeRestriction] = newRangeRestrictions.toList
+
+    def declarations: Seq[FuncDecl] = newDeclarations.toList
+
+    def stalenessState: StalenessState = stalenessTracker.state
+
+    protected def addRangeRestrictions(rangeRestrictions: Set[RangeRestriction]): Unit = {
+        // Add to constraints
+        newConstraints ++= rangeRestrictions map (_.asFormula)
+        newRangeRestrictions ++= rangeRestrictions
+        // Add to used values
+        stalenessTracker.markStale(rangeRestrictions flatMap (_.asFormula.domainElements))
+    }
+
+    protected def addGeneralConstraints(fmls: Set[Term]): Unit = {
+        // Add to constraints
+        newConstraints ++= fmls
+        // Add to used values
+        stalenessTracker.markStale(fmls flatMap (_.domainElements))
+    }
+
+    protected def addDeclaration(f: FuncDecl): Unit = {
+        newDeclarations += f
+    }
+}
+
+trait DefaultPredicateBreakingDL extends SymmetryBreakerDL {
+    override def breakPredicate(P: FuncDecl): Unit = {
+        if (P.argSorts forall (stalenessTracker.state.numFreshValues(_) >= 2)) { // Need at least 2 unused values to do any symmetry breaking
+            val pImplications = SymmetryDL.predicateImplications(P, stalenessTracker.state, disjunctsLimit)
+            addGeneralConstraints(pImplications)
+            if (pImplications.nonEmpty) remainingTracker.markUsedFuncDecls(P)
+        }
+    }
+}
+
+trait DependenceDifferentiationDL extends SymmetryBreakerDL {
+    def breakRDDFunction(f: FuncDecl): Unit
+
+    def breakRDIFunction(f: FuncDecl): Unit
+
+    override def breakFunction(f: FuncDecl): Unit = {
+        if (stalenessTracker.state.existsFreshValue(f.resultSort)) {
+            if (f.isRDD) {
+                breakRDDFunction(f)
+            } else {
+                breakRDIFunction(f)
+            }
+        }
+    }
+}
+
+trait DefaultRDDSchemeDL extends DependenceDifferentiationDL {
+    override def breakRDDFunction(f: FuncDecl): Unit = {
+        val fRangeRestrictions = Symmetry.rddFunctionRangeRestrictions_UsedFirst(f, stalenessTracker.state)
+        addRangeRestrictions(fRangeRestrictions)
+        if (fRangeRestrictions.nonEmpty) remainingTracker.markUsedFuncDecls(f)
+    }
+}
+
+
+trait DefaultRDISchemeDL extends DependenceDifferentiationDL {
+    override def breakRDIFunction(f: FuncDecl): Unit = {
+        val fRangeRestrictions = Symmetry.rdiFunctionRangeRestrictions(f, stalenessTracker.state)
+        val fImplications = Symmetry.rdiFunctionImplicationsSimplified(f, stalenessTracker.state)
+        addRangeRestrictions(fRangeRestrictions)
+        addGeneralConstraints(fImplications)
+        if (fRangeRestrictions.nonEmpty) remainingTracker.markUsedFuncDecls(f)
+    }
+}
+
+
+trait DefaultConstantSchemeDL extends SymmetryBreakerDL {
+    override def breakConstants(sort: Sort, constants: IndexedSeq[AnnotatedVar]): Unit = {
+        val constantRangeRestrictions = Symmetry.csConstantRangeRestrictions(sort, constants, stalenessTracker.state)
+        val constantImplications = Symmetry.csConstantImplicationsSimplified(sort, constants, stalenessTracker.state)
+
+        addRangeRestrictions(constantRangeRestrictions)
+        addGeneralConstraints(constantImplications)
+        remainingTracker.markUsedConstants(constants.take(constantRangeRestrictions.size): _*)
+    }
+}
+
+// Concrete Implementations
+
+class DefaultSymmetryBreakerDL(theory: Theory, stalenessTracker: StalenessTracker, remainingTracker: RemainingIdentifiersTracker, disjunctsLimitParam: Option[Int])
+  extends SymmetryBreakerDL(theory, stalenessTracker: StalenessTracker, remainingTracker: RemainingIdentifiersTracker, disjunctsLimitParam: Option[Int])
+    with DefaultPredicateBreakingDL
+    with DependenceDifferentiationDL
+    with DefaultConstantSchemeDL
+    with DefaultRDISchemeDL
+    with DefaultRDDSchemeDL
+
+case class DefaultSymmetryBreakerFactoryDL(disjunctsLimit: Option[Int] = None) extends SymmetryBreakerFactoryDL {
+    def create(theory: Theory, stalenessTracker: StalenessTracker, remainingTracker: RemainingIdentifiersTracker): SymmetryBreakerDL = new DefaultSymmetryBreakerDL(theory, stalenessTracker, remainingTracker, disjunctsLimit)
+}
+

--- a/core/src/main/scala/fortress/symmetry/SymmetryDL.scala
+++ b/core/src/main/scala/fortress/symmetry/SymmetryDL.scala
@@ -1,0 +1,354 @@
+package fortress.symmetry
+
+import fortress.msfol.DSL._
+import fortress.msfol._
+import fortress.operations.TermOps._
+import fortress.util.Errors
+import fortress.util.Extensions._
+
+import scala.collection.mutable
+
+/** Generate symmetry breaking constraints with disjunctions limit
+  */
+object SymmetryDL {
+    private[this] type ArgList = Seq[Value]
+
+    /** Produces constant range restrictions for one sort like the following:
+      *
+      * c1 = stale values + a1
+      * c2 ∈ stale values + {a1,a2}
+      * c3 ∈ stale values + {a1,a2,a3}
+      * ...
+      */
+    def csConstantRangeRestrictions(
+                                     sort: Sort,
+                                     constants: IndexedSeq[AnnotatedVar],
+                                     state: StalenessState,
+                                     disjunctsLimit: Option[Int] = None
+                                   ): Set[RangeRestriction] = {
+
+        Errors.Internal.precondition(!sort.isBuiltin)
+        Errors.Internal.precondition(constants.forall(_.sort == sort))
+
+        val n = constants.size
+        var m = state.numFreshValues(sort)
+        if (disjunctsLimit.isDefined) {
+            if (state.staleValues(sort).size >= disjunctsLimit.get) return Set.empty
+            m = scala.math.min(m, disjunctsLimit.get - state.staleValues(sort).size)
+        }
+        val r = scala.math.min(n, m)
+
+        val constraints: Seq[RangeRestriction] =
+            for (k <- 0 to (r - 1)) // Enumerate constants
+                yield {
+                    val c_k = constants(k).variable
+
+                    val possibleValues: Seq[DomainElement] =
+                        state.staleValues(sort) ++ // Could be any of the stale values
+                          state.freshValues(sort).take(k + 1) // One of the first k + 1 fresh values (recall, k starts at 0)
+
+                    RangeRestriction(c_k, possibleValues)
+                }
+
+        constraints.toSet
+    }
+
+    /** Produces matching output to csConstantRangeRestrictions - meant to be
+      * used at same time with same input. Sample simplified constant
+      * implications are like the following:
+      *
+      * c2 = a2 ==> a1 = c1
+      *
+      * c3 = a3 ==> a2 = c2
+      * c3 = a2 ==> a1 ∈ {c1,c2}
+      *
+      * c4 = a4 ==> a3 = c3
+      * c4 = a3 ==> a2 ∈ {c2,c3}
+      * c4 = a2 ==> a1 ∈ {c1,c2,c3}
+      * ...
+      */
+    def csConstantImplicationsSimplified(
+                                          sort: Sort,
+                                          constants: IndexedSeq[AnnotatedVar],
+                                          state: StalenessState,
+                                          numRangeFormulaAdded: Int = Int.MaxValue
+                                        ): Set[Term] = {
+
+        Errors.Internal.precondition(!sort.isBuiltin)
+        Errors.Internal.precondition(constants.forall(_.sort == sort))
+
+        val freshValues = state.freshValues(sort)
+
+        val n = constants.size
+        val m = scala.math.min(state.numFreshValues(sort), numRangeFormulaAdded)
+        val r = scala.math.min(n, m)
+
+        val implications = for {
+            i <- 0 to (r - 1) // Enumerates constants
+            j <- 1 to i // Enumerates values, starting with the second
+        } yield {
+            val c_i = constants(i).variable
+
+            val possiblePrecedingConstants = constants.rangeSlice((j - 1) to (i - 1)).map(_.variable)
+
+            (c_i === freshValues(j)) ==> (freshValues(j - 1) equalsOneOfFlip possiblePrecedingConstants)
+        }
+
+        implications.toSet
+    }
+
+    /** Produces range restrictions for range-domain independent function.
+      * Sample rdi range restrictions are like the following:
+      *
+      * f(t1) = stale values + a1
+      * f(t2) ∈ stale values + {a1,a2}
+      * f(t3) ∈ stale values + {a1,a2,a3}
+      * ...
+      */
+    def rdiFunctionRangeRestrictions(
+                                      f: FuncDecl,
+                                      state: StalenessState,
+                                      disjunctsLimit: Option[Int] = None
+                                    ): Set[RangeRestriction] = {
+
+        Errors.Internal.precondition(f.argSorts.forall(!_.isBuiltin))
+        Errors.Internal.precondition(!f.resultSort.isBuiltin)
+        Errors.Internal.precondition(f.isRDI)
+
+        val freshResultValues: IndexedSeq[DomainElement] = state.freshValues(f.resultSort)
+        val staleResultValues = state.staleValues(f.resultSort)
+
+        var m = freshResultValues.size
+        if (disjunctsLimit.isDefined) {
+            if (state.staleValues(f.resultSort).size >= disjunctsLimit.get) return Set.empty
+            m = scala.math.min(m, disjunctsLimit.get - state.staleValues(f.resultSort).size)
+        }
+
+        val argumentListsIterable: Iterable[ArgList] =
+            new fortress.util.ArgumentListGenerator(state.scope(_))
+              .allArgumentListsOfFunction(f)
+              .take(m) // Take up to m of them, for efficiency since we won't need more than this - the argument list generator does not generate arguments
+        // until they are needed
+
+        val argumentLists = argumentListsIterable.toIndexedSeq
+
+        val n = argumentLists.size
+        val r = scala.math.min(m, n)
+
+        val constraints: Seq[RangeRestriction] =
+            for (k <- 0 to (r - 1)) // Enumerate argument vectors
+                yield {
+                    val argList = argumentLists(k)
+                    val possibleResultValues: Seq[DomainElement] =
+                        staleResultValues ++ // Could be any of the stale values
+                          freshResultValues.take(k + 1) // One of the first k + 1 unused values (recall, k starts at 0)
+                    RangeRestriction(App(f.name, argList), possibleResultValues)
+                }
+
+        constraints.toSet
+    }
+
+    /** Produces matching output to rdiFunctionRangeRestrictions - meant to be
+      * used at same time with same input. Sample simplified rdi function
+      * implications are like the following:
+      *
+      * f(t2) = a2 ==> a1 = f(t1)
+      *
+      * f(t3) = a3 ==> a2 = f(t2)
+      * f(t3) = a2 ==> a1 ∈ {f(t1),f(t2)}
+      *
+      * f(t4) = a4 ==> a3 = f(t3)
+      * f(t4) = a3 ==> a2 ∈ {f(t2),f(t3)}
+      * f(t4) = a2 ==> a1 ∈ {f(t1),f(t2),f(t3)}
+      */
+    def rdiFunctionImplicationsSimplified(
+                                           f: FuncDecl,
+                                           state: StalenessState,
+                                           numRangeFormulaAdded: Int = Int.MaxValue
+                                         ): Set[Term] = {
+
+        Errors.Internal.precondition(f.argSorts.forall(!_.isBuiltin))
+        Errors.Internal.precondition(!f.resultSort.isBuiltin)
+        Errors.Internal.precondition(!(f.argSorts contains f.resultSort))
+        Errors.Internal.precondition(f.isRDI)
+
+        val freshResultValues: IndexedSeq[DomainElement] = state.freshValues(f.resultSort)
+
+        val m = scala.math.min(freshResultValues.size, numRangeFormulaAdded)
+
+        val argumentListsIterable: Iterable[ArgList] =
+            new fortress.util.ArgumentListGenerator(state.scope(_))
+              .allArgumentListsOfFunction(f)
+              .take(m) // Take up to m of them, for efficiency since we won't need more than this - the argument list generator does not generate arguments
+        // until they are needed
+
+        val argumentLists = argumentListsIterable.toIndexedSeq
+        val applications: IndexedSeq[Term] = argumentLists map (App(f.name, _))
+
+        val n = applications.size
+
+        val r = scala.math.min(m, n)
+
+        val implications = for {
+            i <- 0 to (r - 1) // Enumerates argVectors
+            j <- 1 to i // Enumerates result values, starting with the second
+        } yield {
+            val app_i = applications(i)
+            val possiblePrecedingApps = applications.rangeSlice((j - 1) to (i - 1))
+            (app_i === freshResultValues(j)) ==> (freshResultValues(j - 1) equalsOneOfFlip possiblePrecedingApps)
+        }
+
+        implications.toSet
+    }
+
+
+    private[this] def predicateImplicationChain(
+                                                 P: FuncDecl,
+                                                 argLists: IndexedSeq[ArgList]
+                                               ): Seq[Term] = {
+
+        for (i <- 1 to (argLists.size - 1)) yield {
+            App(P.name, argLists(i)) ==> App(P.name, argLists(i - 1))
+        }
+    }
+
+    /** Produces predicate implications, which known as ladder implications:
+      *
+      * Q(a2) ==> Q(a1)
+      * Q(a3) ==> Q(a2)
+      * ···
+      * Q(am) ==> Q(am−1)
+      */
+    def predicateImplications(
+                               P: FuncDecl,
+                               state: StalenessState,
+                               numFormulasToAdd: Option[Int] = None
+                             ): Set[Term] = {
+
+        Errors.Internal.precondition(P.resultSort == BoolSort)
+        Errors.Internal.precondition(P.argSorts forall (!_.isBuiltin))
+        Errors.Internal.precondition(P.argSorts exists (state.numFreshValues(_) >= 2))
+
+        val tracker = state.createTrackerWithState
+
+        def fillArgList(sort: Sort, d: DomainElement): ArgList = {
+            Errors.Internal.precondition(d.sort == sort)
+            for (s <- P.argSorts) yield {
+                if (s == sort) d
+                else DomainElement(1, s) // TODO can we make a smarter selection for the other elements?
+            }
+        }
+
+        val constraints = new mutable.ListBuffer[Term]
+        var argSorts = P.argSorts
+
+        while (argSorts exists (tracker.state.numFreshValues(_) >= 2)) {
+            val sort = (argSorts find (tracker.state.numFreshValues(_) >= 2)).get
+            var r = tracker.state.numFreshValues(sort)
+            if (numFormulasToAdd.isDefined) {
+                r = scala.math.min(tracker.state.numFreshValues(sort), numFormulasToAdd.get + 1)
+            }
+            val argLists: IndexedSeq[ArgList] = for (i <- 0 to (r - 1)) yield {
+                fillArgList(sort, tracker.state.freshValues(sort)(i))
+            }
+            val implications = predicateImplicationChain(P, argLists)
+            constraints ++= implications
+            tracker.markStale(implications flatMap (_.domainElements))
+            argSorts = argSorts.filterNot(_ == sort)
+        }
+
+        constraints.toSet
+    }
+
+    /** Produces range restrictions for range-domain dependent function as the
+      * following iteratively:
+      *
+      * f(a) ∈ Stale(A) ∪ {a, a∗}
+      * where a∗ is an arbitrary representative of Fresh(A) \ {a}
+      */
+    private def rddFunctionRangeRestrictionsGeneral(
+                                                     f: FuncDecl,
+                                                     state: StalenessState,
+                                                     argumentOrder: IndexedSeq[DomainElement],
+                                                     disjunctsLimit: Option[Int] = None
+                                                   ): Set[RangeRestriction] = {
+
+        Errors.Internal.precondition(f.argSorts.forall(!_.isBuiltin))
+        Errors.Internal.precondition(!f.resultSort.isBuiltin)
+        Errors.Internal.precondition(f.argSorts contains f.resultSort)
+        Errors.Internal.precondition(!f.isRDI)
+
+        // We fix particular values for the sorts not in the output
+        // These stay the same for all argument lists we symmetry break using
+        // (you don't have to fix particular values, but you can)
+
+        // Construct an argument list given the result value we are using
+        // e.g. if f: A x B x A x D -> A,
+        // given a2 it will yield: (a2, b1, a2, d1)
+        // given a3 it will yield: (a3, b1, a3, d1)
+        def constructArgList(resVal: DomainElement): Seq[DomainElement] = {
+            Errors.Internal.precondition(resVal.sort == f.resultSort)
+            f.argSorts map (sort => {
+                if (sort == f.resultSort) resVal
+                else DomainElement(1, sort) // for other sorts, doesn't matter what values we choose
+            })
+        }
+
+        def constraintForInput(
+                                input: DomainElement,
+                                unusedResultValues: IndexedSeq[DomainElement],
+                                usedResultValues: IndexedSeq[DomainElement]
+                              ): (RangeRestriction, IndexedSeq[DomainElement]) = {
+            val argList = constructArgList(input)
+
+            val possibleResultValues: IndexedSeq[DomainElement] =
+                (usedResultValues :+ // Could be any of the used values
+                  input) ++ // Or itself
+                  Seq(unusedResultValues.find(_ != input)).flatten // Or the first unused value that is not itself
+
+            val rangeRestriction = RangeRestriction(App(f.name, argList), possibleResultValues.distinct)
+            val newlyUsed = possibleResultValues diff usedResultValues
+            (rangeRestriction, newlyUsed)
+        }
+
+        val rangeRestrictions = mutable.Set[RangeRestriction]()
+
+        @scala.annotation.tailrec
+        def loop(index: Int, unused: IndexedSeq[DomainElement], used: IndexedSeq[DomainElement]): Unit = {
+            if (unused.nonEmpty) {
+                val input = argumentOrder(index)
+                val (rangeRestriction, newlyUsed) = constraintForInput(input, unused, used)
+                if (disjunctsLimit.isEmpty || rangeRestriction.values.size <= disjunctsLimit.get) {
+                    rangeRestrictions += rangeRestriction
+                    loop(index + 1, unused diff newlyUsed, used ++ newlyUsed)
+                }
+            }
+        }
+
+        loop(0, state.freshValues(f.resultSort), state.staleValues(f.resultSort))
+
+        rangeRestrictions.toSet
+    }
+
+    def rddFunctionRangeRestrictions_UnusedFirst(
+                                                  f: FuncDecl,
+                                                  state: StalenessState,
+                                                  disjunctsLimit: Option[Int] = None
+                                                ): Set[RangeRestriction] = {
+        rddFunctionRangeRestrictionsGeneral(f, state, state.freshValues(f.resultSort), disjunctsLimit)
+    }
+
+    def rddFunctionRangeRestrictions_UsedFirst(
+                                                f: FuncDecl,
+                                                state: StalenessState,
+                                                disjunctsLimit: Option[Int] = None
+                                              ): Set[RangeRestriction] = {
+        rddFunctionRangeRestrictionsGeneral(
+            f,
+            state,
+            state.staleValues(f.resultSort) ++ state.freshValues(f.resultSort),
+            disjunctsLimit
+        )
+    }
+
+}

--- a/core/src/main/scala/fortress/transformers/SymmetryBreakingTransformer_MostUsed.scala
+++ b/core/src/main/scala/fortress/transformers/SymmetryBreakingTransformer_MostUsed.scala
@@ -1,0 +1,72 @@
+package fortress.transformers
+
+import fortress.msfol._
+import fortress.symmetry._
+import fortress.operations.TheoryOps._
+
+/** Applies symmetry breaking to the given Problem. The input Problem is allowed
+  * to have domain elements in its formulas. The output formula will have domain
+  * elements in its formulas. The resulting Problem has the same scopes, contains
+  * the original axioms plus additional symmetry breaking axioms, and is
+  * equisatisfiable to the original.
+  */
+class SymmetryBreakingTransformer_MostUsed(
+                                            selectionHeuristicFactory: SelectionHeuristicWithConstantsFactory,
+                                            symmetryBreakerFactory: SymmetryBreakerFactoryDL
+                                          ) extends ProblemStateTransformer {
+
+    def apply(problemState: ProblemState): ProblemState = problemState match {
+        case ProblemState(theory, scopes, skc, skf, rangeRestricts, unapplyInterp) => {
+            // This weirdness exists to make sure that this version performs symmetry breaking
+            // on functions in the same order as the previous version
+            // It is only here for the sake of consistency
+            val functions = theory.functionDeclarations filter { fn => {
+                (!fn.resultSort.isBuiltin) && (fn.argSorts forall (!_.isBuiltin))
+            }
+            }
+            val predicates = theory.functionDeclarations.filter { fn => {
+                (fn.resultSort == BoolSort) && (fn.argSorts forall (!_.isBuiltin))
+            }
+            }
+
+            val fp = scala.collection.immutable.ListSet((functions.toList ++ predicates.toList): _*)
+            // END OF WEIRDNESS
+
+            val stalnessTracker = StalenessTracker.create(theory, scopes)
+            val remainingTracker = RemainingIdentifiersTracker.create(theory.constants, fp)
+
+            val breaker = symmetryBreakerFactory.create(theory, stalnessTracker, remainingTracker)
+            val selectionHeuristic = selectionHeuristicFactory.create(stalnessTracker, remainingTracker)
+
+            // Set up the selection heuristic if it is using a preplanned order
+            if (selectionHeuristic.isPreplannedOrder) selectionHeuristic match {
+                case lowArityFirstAndMostUsedOrder: LowArityFirstAndMostUsedOrder =>
+                    lowArityFirstAndMostUsedOrder.prepossess(theory.mostUsedDeclarations)
+                case _ =>
+            }
+
+            @scala.annotation.tailrec
+            def loop(): Unit = {
+                selectionHeuristic.nextSelection() match {
+                    case None => ()
+                    case Some(Left(constants: Seq[AnnotatedVar])) =>
+                        breaker.breakListOfConstants(constants.toIndexedSeq)
+                        loop()
+                    case Some(Right(p@FuncDecl(_, _, BoolSort))) =>
+                        breaker.breakPredicate(p)
+                        loop()
+                    case Some(Right(f@FuncDecl(_, _, _))) =>
+                        breaker.breakFunction(f)
+                        loop()
+                }
+            }
+
+            loop()
+
+            val newTheory = theory.withFunctionDeclarations(breaker.declarations).withAxioms(breaker.constraints)
+            ProblemState(newTheory, scopes, skc, skf, rangeRestricts union breaker.rangeRestrictions.toSet, unapplyInterp)
+        }
+    }
+
+    val name: String = s"Symmetry Breaking Transformer Most Used (${selectionHeuristicFactory.name})"
+}

--- a/core/src/test/scala/operations/TheoryOpsTest.scala
+++ b/core/src/test/scala/operations/TheoryOpsTest.scala
@@ -1,102 +1,123 @@
 import org.scalatest._
-
 import fortress.msfol._
 import fortress.operations.TheoryOps._
 
+import scala.collection.mutable
+
 class TheoryOpsTest extends UnitSuite {
 
-  val A = Sort.mkSortConst("A")
-  val B = Sort.mkSortConst("B")
+    val A = Sort.mkSortConst("A")
+    val B = Sort.mkSortConst("B")
 
-  val c = Var("c")
-  val p = Var("p")
-  val x = Var("x")
-  val y = Var("y")
+    val c = Var("c")
+    val p = Var("p")
+    val x = Var("x")
+    val y = Var("y")
 
-  val f = FuncDecl.mkFuncDecl("f", A, A)
-  val P = FuncDecl.mkFuncDecl("P", A, A, Sort.Bool)
+    val f = FuncDecl.mkFuncDecl("f", A, A)
+    val P = FuncDecl.mkFuncDecl("P", A, A, Sort.Bool)
 
-  val baseTheory = Theory.empty
-    .withSort(A)
-    .withSort(B)
-    .withConstant(p.of(Sort.Bool))
-    .withConstant(c.of(A))
-    .withFunctionDeclaration(f)
-    .withFunctionDeclaration(P)
+    val baseTheory = Theory.empty
+      .withSort(A)
+      .withSort(B)
+      .withConstant(p.of(Sort.Bool))
+      .withConstant(c.of(A))
+      .withFunctionDeclaration(f)
+      .withFunctionDeclaration(P)
 
-  test("sort count") {
-    baseTheory.sortCount should be(2)
-  }
+    test("sort count") {
+        baseTheory.sortCount should be(2)
+    }
 
-  test("function count") {
-    baseTheory.functionCount should be(2)
-  }
+    test("function count") {
+        baseTheory.functionCount should be(2)
+    }
 
-  test("predicate count") {
-    baseTheory.predicateCount should be(1)
-  }
+    test("predicate count") {
+        baseTheory.predicateCount should be(1)
+    }
 
-  test("maximum arity of functions") {
-    val emptyTheory = Theory.empty
+    test("maximum arity of functions") {
+        val emptyTheory = Theory.empty
 
-    emptyTheory.maxFunctionArity should be(0)
-    baseTheory.maxFunctionArity should be(2)
-  }
+        emptyTheory.maxFunctionArity should be(0)
+        baseTheory.maxFunctionArity should be(2)
+    }
 
-  test("boolean sort function args count") {
-    val q = FuncDecl.mkFuncDecl("q", Sort.Bool, Sort.Bool, Sort.Bool)
-    val t = FuncDecl.mkFuncDecl("t", Sort.Bool, A)
-    val theory = baseTheory.withFunctionDeclaration(q)
-        .withFunctionDeclaration(t)
+    test("boolean sort function args count") {
+        val q = FuncDecl.mkFuncDecl("q", Sort.Bool, Sort.Bool, Sort.Bool)
+        val t = FuncDecl.mkFuncDecl("t", Sort.Bool, A)
+        val theory = baseTheory.withFunctionDeclaration(q)
+          .withFunctionDeclaration(t)
 
-    baseTheory.boolArgCount should be(0)
-    theory.boolArgCount should be(3)
-  }
+        baseTheory.boolArgCount should be(0)
+        theory.boolArgCount should be(3)
+    }
 
-  test("term count") {
-    val theory = baseTheory
-      .withAxiom(Forall(x.of(A),
-        Iff(
-          Implication(Eq(c, App("f", x)), App("P", App("f", x), c)),
-          OrList(Top, Bottom)
-        )
-      ))
-      .withAxiom(AndList(Exists(x.of(A), Not(App("P", App("f", x), c))), Bottom))
+    test("term count") {
+        val theory = baseTheory
+          .withAxiom(Forall(x.of(A),
+              Iff(
+                  Implication(Eq(c, App("f", x)), App("P", App("f", x), c)),
+                  OrList(Top, Bottom)
+              )
+          ))
+          .withAxiom(AndList(Exists(x.of(A), Not(App("P", App("f", x), c))), Bottom))
 
-    theory.termCount should be(22)
-  }
+        theory.termCount should be(22)
+    }
 
-  test("maximum depth of quantification among all axioms") {
-    val theory = baseTheory
-      .withAxiom(Forall(x.of(A),
-        Iff(
-          Implication(Eq(c, App("f", x)), App("P", App("f", x), c)),
-          OrList(Top, Bottom)
-        )
-      ))
-      .withAxiom(AndList(Exists(x.of(A), Not(App("P", App("f", x), c))), Bottom))
+    test("maximum depth of quantification among all axioms") {
+        val theory = baseTheory
+          .withAxiom(Forall(x.of(A),
+              Iff(
+                  Implication(Eq(c, App("f", x)), App("P", App("f", x), c)),
+                  OrList(Top, Bottom)
+              )
+          ))
+          .withAxiom(AndList(Exists(x.of(A), Not(App("P", App("f", x), c))), Bottom))
 
-    theory.depthQuantification should be(1)
-  }
+        theory.depthQuantification should be(1)
+    }
 
-  test("maximum depth of nested functions among all axioms") {
-    val theory = baseTheory
-      .withAxiom(Exists(x.of(A),
-        Forall(y.of(A), Implication(Eq(x, App("f", y)), App("P", App("f", y), x))))
-      )
-      .withAxiom(Forall(x.of(A), Not(App("P", App("f", x), c))))
+    test("maximum depth of nested functions among all axioms") {
+        val theory = baseTheory
+          .withAxiom(Exists(x.of(A),
+              Forall(y.of(A), Implication(Eq(x, App("f", y)), App("P", App("f", y), x))))
+          )
+          .withAxiom(Forall(x.of(A), Not(App("P", App("f", x), c))))
 
-    theory.depthQuantification should be(2)
-  }
+        theory.depthQuantification should be(2)
+    }
 
-  test("Sort Inference metrics: new sorts inferred") {
-    val f = FuncDecl("f", A, A, A)
+    test("Sort Inference metrics: new sorts inferred") {
+        val f = FuncDecl("f", A, A, A)
 
-    val theory = Theory.empty
-      .withSorts(A)
-      .withFunctionDeclarations(f)
+        val theory = Theory.empty
+          .withSorts(A)
+          .withFunctionDeclarations(f)
 
-    theory.inferSortsCount should be(2)
-    theory.newSortsInferred should be(true)
-  }
+        theory.inferSortsCount should be(2)
+        theory.newSortsInferred should be(true)
+    }
+
+    test("most used declarations: counting occurrences correctly") {
+        val theory = baseTheory
+          .withAxiom(Forall(x.of(A),
+              Iff(
+                  Implication(Eq(c, App("f", x)), App("P", App("f", x), c)),
+                  OrList(Top, Bottom)
+              )
+          ))
+          .withAxiom(AndList(Exists(x.of(A), Not(App("P", App("f", x), c))), Bottom))
+
+        val result = theory.mostUsedDeclarations
+        val expected = Map(
+            FuncDecl("P", A, A, BoolSort) -> 2,
+            FuncDecl("f", A, A) -> 3,
+            AnnotatedVar(Var("c"), A) -> 3,
+            AnnotatedVar(Var("p"), BoolSort) -> 0)
+
+        result should be(expected)
+    }
 }

--- a/core/src/test/scala/symmetry/SymmetryBreakDLTests_Constants.scala
+++ b/core/src/test/scala/symmetry/SymmetryBreakDLTests_Constants.scala
@@ -1,0 +1,139 @@
+import org.scalatest._
+
+import fortress.msfol._
+import fortress.operations.TermOps._
+import fortress.symmetry._
+
+class SymmetryBreakDLTests_Constants extends UnitSuite {
+    
+    val A: Sort = SortConst("A")
+    val B: Sort = SortConst("B")
+    val D: Sort = SortConst("D")
+    
+    val c1 = Var("c1")
+    val c2 = Var("c2")
+    val c3 = Var("c3")
+    val c4 = Var("c4")
+    val c5 = Var("c5")
+    
+    def DE(index: Int, sort: Sort) = DomainElement(index, sort)
+
+    test("CS Constant - Equalities (Without Disjuncts Limit)") {
+        val constants = IndexedSeq(
+            c1 of B,
+            c2 of B,
+            c3 of B,
+            c4 of B,
+            c5 of B)
+        
+        val usedValues = IndexedSeq(
+            DE(1, B),
+            DE(3, B),
+            DE(5, B),
+        )
+        
+        val scopes = Map(B -> 7)
+        val used = Map(B -> usedValues)
+        val state = StalenessState(Set(B), scopes, used)
+        
+        SymmetryDL.csConstantRangeRestrictions(B, constants, state) map (_.asFormula) should be (
+            Set(
+                Or(c1 === DE(1, B), c1 === DE(3, B), c1 === DE(5, B), c1 === DE(2, B)),
+                Or(c2 === DE(1, B), c2 === DE(3, B), c2 === DE(5, B), c2 === DE(2, B), c2 === DE(4, B)),
+                Or(c3 === DE(1, B), c3 === DE(3, B), c3 === DE(5, B), c3 === DE(2, B), c3 === DE(4, B), c3 === DE(6, B)),
+                Or(c4 === DE(1, B), c4 === DE(3, B), c4 === DE(5, B), c4 === DE(2, B), c4 === DE(4, B), c4 === DE(6, B), c4 === DE(7, B)),
+            )
+        )
+    }
+
+    test("CS Constant - Implications, Simplified (Without Disjuncts Limit)") {
+        val constants = IndexedSeq(
+            c1 of B,
+            c2 of B,
+            c3 of B,
+            c4 of B,
+            c5 of B)
+        
+        val usedValues = IndexedSeq(
+            DE(1, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 2, 4, 6, 7
+        
+        val scopes = Map(B -> 7)
+        val used = Map(B -> usedValues)
+        val state = StalenessState(Set(B), scopes, used)
+        
+        val constraints = SymmetryDL.csConstantImplicationsSimplified(B, constants, state)
+        constraints should have size 6
+        
+        constraints should contain { (c2 === DE(4, B)) ==> (DE(2, B) equalsOneOfFlip Seq(c1)) }
+        
+        constraints should contain { (c3 === DE(4, B)) ==> (DE(2, B) equalsOneOfFlip Seq(c1, c2)) }
+        constraints should contain { (c3 === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(c2)) }
+        
+        constraints should contain { (c4 === DE(4, B)) ==> (DE(2, B) equalsOneOfFlip Seq(c1, c2, c3)) }
+        constraints should contain { (c4 === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(c2, c3)) }
+        constraints should contain { (c4 === DE(7, B)) ==> (DE(6, B) equalsOneOfFlip Seq(c3)) }
+    }
+
+    test("CS Constant - Equalities (With Disjuncts Limit)") {
+        val constants = IndexedSeq(
+            c1 of B,
+            c2 of B,
+            c3 of B,
+            c4 of B,
+            c5 of B)
+
+        val usedValues = IndexedSeq(
+            DE(1, B),
+            DE(3, B),
+            DE(5, B),
+        )
+
+        val scopes = Map(B -> 7)
+        val used = Map(B -> usedValues)
+        val state = StalenessState(Set(B), scopes, used)
+
+        SymmetryDL.csConstantRangeRestrictions(B, constants, state, Some(6)) map (_.asFormula) should be(
+            Set(
+                Or(c1 === DE(1, B), c1 === DE(3, B), c1 === DE(5, B), c1 === DE(2, B)),
+                Or(c2 === DE(1, B), c2 === DE(3, B), c2 === DE(5, B), c2 === DE(2, B), c2 === DE(4, B)),
+                Or(c3 === DE(1, B), c3 === DE(3, B), c3 === DE(5, B), c3 === DE(2, B), c3 === DE(4, B), c3 === DE(6, B)),
+            )
+        )
+    }
+
+    test("CS Constant - Implications, Simplified (With Disjuncts Limit)") {
+        val constants = IndexedSeq(
+            c1 of B,
+            c2 of B,
+            c3 of B,
+            c4 of B,
+            c5 of B)
+
+        val usedValues = IndexedSeq(
+            DE(1, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 2, 4, 6, 7
+
+        val scopes = Map(B -> 7)
+        val used = Map(B -> usedValues)
+        val state = StalenessState(Set(B), scopes, used)
+
+        val constraints = SymmetryDL.csConstantImplicationsSimplified(B, constants, state, 3)
+        constraints should have size 3
+
+        constraints should contain {
+            (c2 === DE(4, B)) ==> (DE(2, B) equalsOneOfFlip Seq(c1))
+        }
+
+        constraints should contain {
+            (c3 === DE(4, B)) ==> (DE(2, B) equalsOneOfFlip Seq(c1, c2))
+        }
+        constraints should contain {
+            (c3 === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(c2))
+        }
+    }
+}

--- a/core/src/test/scala/symmetry/SymmetryBreakDLTests_Predicates.scala
+++ b/core/src/test/scala/symmetry/SymmetryBreakDLTests_Predicates.scala
@@ -1,0 +1,126 @@
+import org.scalatest._
+
+import fortress.msfol._
+import fortress.symmetry._
+
+class SymmetryBreakDLTests_Predicates extends UnitSuite {
+    
+    val A: Sort = SortConst("A")
+    val B: Sort = SortConst("B")
+    val D: Sort = SortConst("D")
+    
+    val c1 = Var("c1")
+    val c2 = Var("c2")
+    val c3 = Var("c3")
+    val c4 = Var("c4")
+    val c5 = Var("c5")
+    
+    def DE(index: Int, sort: Sort) = DomainElement(index, sort)
+
+    test("Predicates - Unary (Without Disjuncts Limit)") {
+        val P = FuncDecl("P", A, BoolSort)
+        
+        val usedValsA = IndexedSeq(
+            DE(1, A),
+            DE(2, A),
+            DE(5, A)
+        ) // Unused 3, 4, 6, 7, 8, 9
+        
+        val usedValues = Map(A -> usedValsA)
+        val scopes = Map(A -> 9)
+        val state = StalenessState(Set(A), scopes, usedValues)
+        
+        val constraints = SymmetryDL.predicateImplications(P, state)
+        constraints should have size 5
+        constraints should contain (App("P", DE(4, A)) ==> App("P", DE(3, A)))
+        constraints should contain (App("P", DE(6, A)) ==> App("P", DE(4, A)))
+        constraints should contain (App("P", DE(7, A)) ==> App("P", DE(6, A)))
+        constraints should contain (App("P", DE(8, A)) ==> App("P", DE(7, A)))
+        constraints should contain (App("P", DE(9, A)) ==> App("P", DE(8, A)))
+    }
+    
+    test("Predicates - Ternary, MultiSort (Without Disjuncts Limit)") {
+        val P = FuncDecl("P", A, B, A, BoolSort)
+        
+        val usedValsA = IndexedSeq(
+            DE(1, A),
+            DE(2, A),
+            DE(5, A)
+        ) // Unused 3, 4, 6, 7, 8, 9
+        
+        val usedValsB = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(4, B)
+        ) // Unused 1, 5, 6, 7, 8
+        
+        val usedValues = Map(A -> usedValsA, B -> usedValsB)
+        val scopes = Map(A -> 9, B -> 8)
+        val state = StalenessState(Set(A, B), scopes, usedValues)
+        
+        val constraints = SymmetryDL.predicateImplications(P, state)
+        constraints should have size 8
+        // A constraints
+        constraints should contain (App("P", DE(4, A), DE(1, B), DE(4, A)) ==> (App("P", DE(3, A), DE(1, B), DE(3, A))))
+        constraints should contain (App("P", DE(6, A), DE(1, B), DE(6, A)) ==> (App("P", DE(4, A), DE(1, B), DE(4, A)))) 
+        constraints should contain (App("P", DE(7, A), DE(1, B), DE(7, A)) ==> (App("P", DE(6, A), DE(1, B), DE(6, A))))
+        constraints should contain (App("P", DE(8, A), DE(1, B), DE(8, A)) ==> (App("P", DE(7, A), DE(1, B), DE(7, A))))
+        constraints should contain (App("P", DE(9, A), DE(1, B), DE(9, A)) ==> (App("P", DE(8, A), DE(1, B), DE(8, A))))
+        // B constraints - note that now 1B has been used... so now just 5, 6, 7, 8
+        constraints should contain (App("P", DE(1, A), DE(6, B), DE(1, A)) ==> (App("P", DE(1, A), DE(5, B), DE(1, A)))) 
+        constraints should contain (App("P", DE(1, A), DE(7, B), DE(1, A)) ==> (App("P", DE(1, A), DE(6, B), DE(1, A)))) 
+        constraints should contain (App("P", DE(1, A), DE(8, B), DE(1, A)) ==> (App("P", DE(1, A), DE(7, B), DE(1, A)))) 
+    }
+
+
+    test("Predicates - Unary (With Disjuncts Limit)") {
+        val P = FuncDecl("P", A, BoolSort)
+
+        val usedValsA = IndexedSeq(
+            DE(1, A),
+            DE(2, A),
+            DE(5, A)
+        ) // Unused 3, 4, 6, 7, 8, 9
+
+        val usedValues = Map(A -> usedValsA)
+        val scopes = Map(A -> 9)
+        val state = StalenessState(Set(A), scopes, usedValues)
+
+        val constraints = SymmetryDL.predicateImplications(P, state, Some(3))
+        constraints should have size 3
+        constraints should contain(App("P", DE(4, A)) ==> App("P", DE(3, A)))
+        constraints should contain(App("P", DE(6, A)) ==> App("P", DE(4, A)))
+        constraints should contain(App("P", DE(7, A)) ==> App("P", DE(6, A)))
+    }
+
+    test("Predicates - Ternary, MultiSort  (With Disjuncts Limit)") {
+        val P = FuncDecl("P", A, B, A, BoolSort)
+
+        val usedValsA = IndexedSeq(
+            DE(1, A),
+            DE(2, A),
+            DE(5, A)
+        ) // Unused 3, 4, 6, 7, 8, 9
+
+        val usedValsB = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(4, B)
+        ) // Unused 1, 5, 6, 7, 8
+
+        val usedValues = Map(A -> usedValsA, B -> usedValsB)
+        val scopes = Map(A -> 9, B -> 8)
+        val state = StalenessState(Set(A, B), scopes, usedValues)
+
+        val constraints = SymmetryDL.predicateImplications(P, state, Some(3))
+        constraints should have size 6
+        // A constraints
+        constraints should contain(App("P", DE(4, A), DE(1, B), DE(4, A)) ==> (App("P", DE(3, A), DE(1, B), DE(3, A))))
+        constraints should contain(App("P", DE(6, A), DE(1, B), DE(6, A)) ==> (App("P", DE(4, A), DE(1, B), DE(4, A))))
+        constraints should contain(App("P", DE(7, A), DE(1, B), DE(7, A)) ==> (App("P", DE(6, A), DE(1, B), DE(6, A))))
+        // B constraints - note that now 1B has been used... so now just 5, 6, 7, 8
+        constraints should contain(App("P", DE(1, A), DE(6, B), DE(1, A)) ==> (App("P", DE(1, A), DE(5, B), DE(1, A))))
+        constraints should contain(App("P", DE(1, A), DE(7, B), DE(1, A)) ==> (App("P", DE(1, A), DE(6, B), DE(1, A))))
+        constraints should contain(App("P", DE(1, A), DE(8, B), DE(1, A)) ==> (App("P", DE(1, A), DE(7, B), DE(1, A))))
+    }
+}

--- a/core/src/test/scala/symmetry/SymmetryBreakDLTests_RDD.scala
+++ b/core/src/test/scala/symmetry/SymmetryBreakDLTests_RDD.scala
@@ -1,0 +1,361 @@
+import org.scalatest._
+
+import fortress.msfol._
+import fortress.symmetry._
+
+class SymmetryBreakDLTests_RDD extends UnitSuite {
+    
+    val A: Sort = SortConst("A")
+    val B: Sort = SortConst("B")
+    val D: Sort = SortConst("D")
+    
+    val c1 = Var("c1")
+    val c2 = Var("c2")
+    val c3 = Var("c3")
+    val c4 = Var("c4")
+    val c5 = Var("c5")
+    
+    def DE(index: Int, sort: Sort) = DomainElement(index, sort)
+
+    test("rdd Functions - Unused First, Pure, Unary (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A)
+        
+        val usedResultValues = IndexedSeq()
+        
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+        
+        val f1A = for(i <- Seq(1, 2)) yield {App("f", DE(1, A)) === DE(i, A)}
+        val f2A = for(i <- Seq(1, 2, 3)) yield {App("f", DE(2, A)) === DE(i, A)}
+        val f3A = for(i <- Seq(1, 2, 3, 4)) yield {App("f", DE(3, A)) === DE(i, A)}
+        val f4A = for(i <- Seq(1, 2, 3, 4, 5)) yield {App("f", DE(4, A)) === DE(i, A)}
+        val f5A = for(i <- Seq(1, 2, 3, 4, 5, 6)) yield {App("f", DE(5, A)) === DE(i, A)}
+        val f6A = for(i <- Seq(1, 2, 3, 4, 5, 6, 7)) yield {App("f", DE(6, A)) === DE(i, A)}
+        val f7A = for(i <- Seq(1, 2, 3, 4, 5, 6, 7, 8)) yield {App("f", DE(7, A)) === DE(i, A)}
+        val f8A = for(i <- Seq(1, 2, 3, 4, 5, 6, 7, 8, 9)) yield {App("f", DE(8, A)) === DE(i, A)}
+        
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UnusedFirst(f, state) map (_.asFormula)
+        constraints should have size 8
+        constraints should contain (OrList(f1A))
+        constraints should contain (OrList(f2A))
+        constraints should contain (OrList(f3A))
+        constraints should contain (OrList(f4A))
+        constraints should contain (OrList(f5A))
+        constraints should contain (OrList(f6A))
+        constraints should contain (OrList(f7A))
+        constraints should contain (OrList(f8A))
+    }
+
+    test("rdd Functions - Unused First, Unary (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A)
+        
+        val usedResultValues = IndexedSeq(
+            DE(1, A),
+            DE(3, A),
+            DE(4, A),
+            DE(6, A)
+        ) // Unused 2 5 7 8 9
+        
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+        
+        val f2A = for(i <- Seq(1, 3, 4, 6, 2, 5)) yield {App("f", DE(2, A)) === DE(i, A)}
+        val f5A = for(i <- Seq(1, 3, 4, 6, 2, 5, 7)) yield {App("f", DE(5, A)) === DE(i, A)}
+        val f7A = for(i <- Seq(1, 3, 4, 6, 2, 5, 7, 8)) yield {App("f", DE(7, A)) === DE(i, A)}
+        val f8A = for(i <- Seq(1, 3, 4, 6, 2, 5, 7, 8, 9)) yield {App("f", DE(8, A)) === DE(i, A)}
+        
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UnusedFirst(f, state) map (_.asFormula)
+        constraints should have size 4
+        constraints should contain (OrList(f2A))
+        constraints should contain (OrList(f5A))
+        constraints should contain (OrList(f7A))
+        constraints should contain (OrList(f8A))
+    }
+    
+    test("rdd Functions - Unused First, Binary, Single-sort (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A, A)
+        
+        val usedResultValues = IndexedSeq(
+            DE(1, A),
+            DE(3, A),
+            DE(4, A),
+            DE(6, A)
+        ) // Unused 2 5 7 8 9
+        
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+        
+        val f22 = for(i <- Seq(1, 3, 4, 6, 2, 5)) yield {App("f", DE(2, A), DE(2, A)) === DE(i, A)}
+        val f55 = for(i <- Seq(1, 3, 4, 6, 2, 5, 7)) yield {App("f", DE(5, A), DE(5, A)) === DE(i, A)}
+        val f77 = for(i <- Seq(1, 3, 4, 6, 2, 5, 7, 8)) yield {App("f", DE(7, A), DE(7, A)) === DE(i, A)}
+        val f88 = for(i <- Seq(1, 3, 4, 6, 2, 5, 7, 8, 9)) yield {App("f", DE(8, A), DE(8, A)) === DE(i, A)}
+        
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UnusedFirst(f, state) map (_.asFormula)
+        constraints should have size 4
+        constraints should contain (OrList(f22))
+        constraints should contain (OrList(f55))
+        constraints should contain (OrList(f77))
+        constraints should contain (OrList(f88))
+    }
+    
+    test("rdd Functions - Unused First, 4-ary, Multi-sort (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, D, A, B, A)
+        
+        val usedResultValues = IndexedSeq(
+            DE(1, A),
+            DE(3, A),
+            DE(4, A),
+            DE(6, A)
+        ) // Unused 2 5 7 8 9
+        
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A, D, B), scopes, used)
+        
+        val f2121 = for(i <- Seq(1, 3, 4, 6, 2, 5)) yield {App("f", DE(2, A), DE(1, D), DE(2, A), DE(1, B)) === DE(i, A)}
+        val f5151 = for(i <- Seq(1, 3, 4, 6, 2, 5, 7)) yield {App("f", DE(5, A), DE(1, D), DE(5, A), DE(1, B)) === DE(i, A)}
+        val f7171 = for(i <- Seq(1, 3, 4, 6, 2, 5, 7, 8)) yield {App("f", DE(7, A), DE(1, D), DE(7, A), DE(1, B)) === DE(i, A)}
+        val f8181 = for(i <- Seq(1, 3, 4, 6, 2, 5, 7, 8, 9)) yield {App("f", DE(8, A), DE(1, D), DE(8, A), DE(1, B)) === DE(i, A)}
+        
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UnusedFirst(f, state) map (_.asFormula)
+        constraints should have size 4
+        constraints should contain (OrList(f2121))
+        constraints should contain (OrList(f5151))
+        constraints should contain (OrList(f7171))
+        constraints should contain (OrList(f8181))
+    }
+
+    test("rdd Functions - Used First, Pure, Unary (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A)
+        
+        val usedResultValues = IndexedSeq()
+        
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+        
+        val f1A = for(i <- Seq(1, 2)) yield {App("f", DE(1, A)) === DE(i, A)}
+        val f2A = for(i <- Seq(1, 2, 3)) yield {App("f", DE(2, A)) === DE(i, A)}
+        val f3A = for(i <- Seq(1, 2, 3, 4)) yield {App("f", DE(3, A)) === DE(i, A)}
+        val f4A = for(i <- Seq(1, 2, 3, 4, 5)) yield {App("f", DE(4, A)) === DE(i, A)}
+        val f5A = for(i <- Seq(1, 2, 3, 4, 5, 6)) yield {App("f", DE(5, A)) === DE(i, A)}
+        val f6A = for(i <- Seq(1, 2, 3, 4, 5, 6, 7)) yield {App("f", DE(6, A)) === DE(i, A)}
+        val f7A = for(i <- Seq(1, 2, 3, 4, 5, 6, 7, 8)) yield {App("f", DE(7, A)) === DE(i, A)}
+        val f8A = for(i <- Seq(1, 2, 3, 4, 5, 6, 7, 8, 9)) yield {App("f", DE(8, A)) === DE(i, A)}
+        
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UsedFirst(f, state) map (_.asFormula)
+        constraints should have size 8
+        constraints should contain (OrList(f1A))
+        constraints should contain (OrList(f2A))
+        constraints should contain (OrList(f3A))
+        constraints should contain (OrList(f4A))
+        constraints should contain (OrList(f5A))
+        constraints should contain (OrList(f6A))
+        constraints should contain (OrList(f7A))
+        constraints should contain (OrList(f8A))
+    }
+
+    test("rdd Functions - Used First, Unary (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A)
+        
+        val usedResultValues = IndexedSeq(
+            DE(1, A),
+            DE(3, A),
+            DE(4, A),
+            DE(6, A)
+        ) // Unused 2 5 7 8 9
+        
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+        
+        val f1A = for(i <- Seq(1, 3, 4, 6, 2)) yield {App("f", DE(1, A)) === DE(i, A)}
+        val f3A = for(i <- Seq(1, 3, 4, 6, 2, 5)) yield {App("f", DE(3, A)) === DE(i, A)}
+        val f4A = for(i <- Seq(1, 3, 4, 6, 2, 5, 7)) yield {App("f", DE(4, A)) === DE(i, A)}
+        val f6A = for(i <- Seq(1, 3, 4, 6, 2, 5, 7, 8)) yield {App("f", DE(6, A)) === DE(i, A)}
+        val f2A = for(i <- Seq(1, 3, 4, 6, 2, 5, 7, 8, 9)) yield {App("f", DE(2, A)) === DE(i, A)}
+        
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UsedFirst(f, state) map (_.asFormula)
+        constraints should have size 5
+        constraints should contain (OrList(f1A))
+        constraints should contain (OrList(f3A))
+        constraints should contain (OrList(f4A))
+        constraints should contain (OrList(f6A))
+        constraints should contain (OrList(f2A))
+    }
+
+    test("rdd Functions - Unused First, Pure, Unary (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A)
+
+        val usedResultValues = IndexedSeq()
+
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+
+        val f1A = for (i <- Seq(1, 2)) yield {
+            App("f", DE(1, A)) === DE(i, A)
+        }
+        val f2A = for (i <- Seq(1, 2, 3)) yield {
+            App("f", DE(2, A)) === DE(i, A)
+        }
+        val f3A = for (i <- Seq(1, 2, 3, 4)) yield {
+            App("f", DE(3, A)) === DE(i, A)
+        }
+
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UnusedFirst(f, state, Some(4)) map (_.asFormula)
+        constraints should have size 3
+        constraints should contain(OrList(f1A))
+        constraints should contain(OrList(f2A))
+        constraints should contain(OrList(f3A))
+    }
+
+    test("rdd Functions - Unused First, Unary (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A)
+
+        val usedResultValues = IndexedSeq(
+            DE(1, A),
+            DE(3, A),
+            DE(4, A),
+            DE(6, A)
+        ) // Unused 2 5 7 8 9
+
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+
+        val f2A = for (i <- Seq(1, 3, 4, 6, 2, 5)) yield {
+            App("f", DE(2, A)) === DE(i, A)
+        }
+        val f5A = for (i <- Seq(1, 3, 4, 6, 2, 5, 7)) yield {
+            App("f", DE(5, A)) === DE(i, A)
+        }
+
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UnusedFirst(f, state, Some(7)) map (_.asFormula)
+        constraints should have size 2
+        constraints should contain(OrList(f2A))
+        constraints should contain(OrList(f5A))
+    }
+
+    test("rdd Functions - Unused First, Binary, Single-sort (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A, A)
+
+        val usedResultValues = IndexedSeq(
+            DE(1, A),
+            DE(3, A),
+            DE(4, A),
+            DE(6, A)
+        ) // Unused 2 5 7 8 9
+
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+
+        val f22 = for (i <- Seq(1, 3, 4, 6, 2, 5)) yield {
+            App("f", DE(2, A), DE(2, A)) === DE(i, A)
+        }
+        val f55 = for (i <- Seq(1, 3, 4, 6, 2, 5, 7)) yield {
+            App("f", DE(5, A), DE(5, A)) === DE(i, A)
+        }
+        val f77 = for (i <- Seq(1, 3, 4, 6, 2, 5, 7, 8)) yield {
+            App("f", DE(7, A), DE(7, A)) === DE(i, A)
+        }
+
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UnusedFirst(f, state, Some(8)) map (_.asFormula)
+        constraints should have size 3
+        constraints should contain(OrList(f22))
+        constraints should contain(OrList(f55))
+        constraints should contain(OrList(f77))
+    }
+
+    test("rdd Functions - Unused First, 4-ary, Multi-sort (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, D, A, B, A)
+
+        val usedResultValues = IndexedSeq(
+            DE(1, A),
+            DE(3, A),
+            DE(4, A),
+            DE(6, A)
+        ) // Unused 2 5 7 8 9
+
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A, D, B), scopes, used)
+
+        val f2121 = for (i <- Seq(1, 3, 4, 6, 2, 5)) yield {
+            App("f", DE(2, A), DE(1, D), DE(2, A), DE(1, B)) === DE(i, A)
+        }
+        val f5151 = for (i <- Seq(1, 3, 4, 6, 2, 5, 7)) yield {
+            App("f", DE(5, A), DE(1, D), DE(5, A), DE(1, B)) === DE(i, A)
+        }
+        val f7171 = for (i <- Seq(1, 3, 4, 6, 2, 5, 7, 8)) yield {
+            App("f", DE(7, A), DE(1, D), DE(7, A), DE(1, B)) === DE(i, A)
+        }
+
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UnusedFirst(f, state, Some(8)) map (_.asFormula)
+        constraints should have size 3
+        constraints should contain(OrList(f2121))
+        constraints should contain(OrList(f5151))
+        constraints should contain(OrList(f7171))
+    }
+
+    test("rdd Functions - Used First, Pure, Unary (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A)
+
+        val usedResultValues = IndexedSeq()
+
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+
+        val f1A = for (i <- Seq(1, 2)) yield {
+            App("f", DE(1, A)) === DE(i, A)
+        }
+        val f2A = for (i <- Seq(1, 2, 3)) yield {
+            App("f", DE(2, A)) === DE(i, A)
+        }
+        val f3A = for (i <- Seq(1, 2, 3, 4)) yield {
+            App("f", DE(3, A)) === DE(i, A)
+        }
+
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UsedFirst(f, state, Some(4)) map (_.asFormula)
+        constraints should have size 3
+        constraints should contain(OrList(f1A))
+        constraints should contain(OrList(f2A))
+        constraints should contain(OrList(f3A))
+    }
+
+    test("rdd Functions - Used First, Unary (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, A)
+
+        val usedResultValues = IndexedSeq(
+            DE(1, A),
+            DE(3, A),
+            DE(4, A),
+            DE(6, A)
+        ) // Unused 2 5 7 8 9
+
+        val scopes = Map(A -> 9)
+        val used = Map(A -> usedResultValues)
+        val state = StalenessState(Set(A), scopes, used)
+
+        val f1A = for (i <- Seq(1, 3, 4, 6, 2)) yield {
+            App("f", DE(1, A)) === DE(i, A)
+        }
+        val f3A = for (i <- Seq(1, 3, 4, 6, 2, 5)) yield {
+            App("f", DE(3, A)) === DE(i, A)
+        }
+        val f4A = for (i <- Seq(1, 3, 4, 6, 2, 5, 7)) yield {
+            App("f", DE(4, A)) === DE(i, A)
+        }
+
+        val constraints = SymmetryDL.rddFunctionRangeRestrictions_UsedFirst(f, state, Some(7)) map (_.asFormula)
+        constraints should have size 3
+        constraints should contain(OrList(f1A))
+        constraints should contain(OrList(f3A))
+        constraints should contain(OrList(f4A))
+    }
+}

--- a/core/src/test/scala/symmetry/SymmetryBreakDLTests_RDI.scala
+++ b/core/src/test/scala/symmetry/SymmetryBreakDLTests_RDI.scala
@@ -1,0 +1,279 @@
+import org.scalatest._
+
+import fortress.msfol._
+import fortress.operations.TermOps._
+import fortress.symmetry._
+
+class SymmetryBreakDLTests_RDI extends UnitSuite {
+    val A: Sort = SortConst("A")
+    val B: Sort = SortConst("B")
+    val D: Sort = SortConst("D")
+    
+    val c1 = Var("c1")
+    val c2 = Var("c2")
+    val c3 = Var("c3")
+    val c4 = Var("c4")
+    val c5 = Var("c5")
+    
+    def DE(index: Int, sort: Sort) = DomainElement(index, sort)
+
+    test("rdi Unary - Equalities (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, B)
+        
+        val usedResultValues = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 1, 4, 6, 7
+        
+        val scopes = Map(A -> 8, B -> 7)
+        val used = Map(B -> usedResultValues)
+        val state = StalenessState(Set(A, B), scopes, used)
+        
+        val f1A = for (i <- Seq(2, 3, 5, 1)) yield {App("f", DE(1, A)) === DE(i, B)}
+        val f2A = for (i <- Seq(2, 3, 5, 1, 4)) yield {App("f", DE(2, A)) === DE(i, B)}
+        val f3A = for (i <- Seq(2, 3, 5, 1, 4, 6)) yield {App("f", DE(3, A)) === DE(i, B)}
+        val f4A = for (i <- Seq(2, 3, 5, 1, 4, 6, 7)) yield {App("f", DE(4, A)) === DE(i, B)}
+        
+        SymmetryDL.rdiFunctionRangeRestrictions(f, state) map (_.asFormula) should be (
+            Set(
+                OrList(f1A),
+                OrList(f2A),
+                OrList(f3A),
+                OrList(f4A)
+            )
+        )
+    }
+    
+    test("rdi Ternary - Equalities (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, D, A, B)
+        
+        val usedResultValues = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 1, 4, 6, 7, 8, 9
+        
+        val scopes = Map(A -> 2, D -> 2, B -> 9)
+        val used = Map(B -> usedResultValues)
+        val state = StalenessState(Set(A, D, B), scopes, used)
+        
+        val f111 = for (i <- Seq(2, 3, 5, 1)) yield {App("f", DE(1, A), DE(1, D), DE(1, A)) === DE(i, B)}
+        val f211 = for (i <- Seq(2, 3, 5, 1, 4)) yield {App("f", DE(2, A), DE(1, D), DE(1, A)) === DE(i, B)}
+        val f121 = for (i <- Seq(2, 3, 5, 1, 4, 6)) yield {App("f", DE(1, A), DE(2, D), DE(1, A)) === DE(i, B)}
+        val f221 = for (i <- Seq(2, 3, 5, 1, 4, 6, 7)) yield {App("f", DE(2, A), DE(2, D), DE(1, A)) === DE(i, B)}
+        val f112 = for (i <- Seq(2, 3, 5, 1, 4, 6, 7, 8)) yield {App("f", DE(1, A), DE(1, D), DE(2, A)) === DE(i, B)}
+        val f212 = for (i <- Seq(2, 3, 5, 1, 4, 6, 7, 8, 9)) yield {App("f", DE(2, A), DE(1, D), DE(2, A)) === DE(i, B)}
+        
+        val constraints = SymmetryDL.rdiFunctionRangeRestrictions(f, state) map (_.asFormula)
+        constraints should have size 6
+        constraints should contain (OrList(f111))
+        constraints should contain (OrList(f211))
+        constraints should contain (OrList(f121))
+        constraints should contain (OrList(f221))
+        constraints should contain (OrList(f112))
+        constraints should contain (OrList(f212))
+    }
+
+    test("rdi Unary - Implications, Simplified (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, B)
+        
+        val usedResultValues = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 1, 4, 6, 7
+        
+        val scopes: Map[Sort, Int] = Map(A -> 8, B -> 7)
+        val used = Map(B -> usedResultValues)
+        val state = StalenessState(Set(A, B), scopes, used)
+        
+        val f1A = App("f", DE(1, A))
+        val f2A = App("f", DE(2, A))
+        val f3A = App("f", DE(3, A))
+        val f4A = App("f", DE(4, A))
+        
+        val constraints = SymmetryDL.rdiFunctionImplicationsSimplified(f, state)
+        
+        constraints should have size 6
+        
+        constraints should contain { (f2A === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f1A)) }
+        
+        constraints should contain { (f3A === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f1A, f2A)) }
+        constraints should contain { (f3A === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(f2A)) }
+        
+        constraints should contain { (f4A === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f1A, f2A, f3A)) }
+        constraints should contain { (f4A === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(f2A, f3A)) }
+        constraints should contain { (f4A === DE(7, B)) ==> (DE(6, B) equalsOneOfFlip Seq(f3A)) }
+    }
+    
+    test("rdi Ternary - Implications, Simplified (Without Disjuncts Limit)") {
+        val f = FuncDecl("f", A, D, A, B)
+        
+        val usedResultValues = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 1, 4, 6, 7, 8, 9
+        
+        val scopes = Map(A -> 2, D -> 2, B -> 9)
+        val used = Map(B -> usedResultValues)
+        val state = StalenessState(Set(A, D, B), scopes, used)
+        
+        val f111 = App("f", DE(1, A), DE(1, D), DE(1, A))
+        val f211 = App("f", DE(2, A), DE(1, D), DE(1, A))
+        val f121 = App("f", DE(1, A), DE(2, D), DE(1, A))
+        val f221 = App("f", DE(2, A), DE(2, D), DE(1, A))
+        val f112 = App("f", DE(1, A), DE(1, D), DE(2, A))
+        val f212 = App("f", DE(2, A), DE(1, D), DE(2, A))
+        
+        val constraints = SymmetryDL.rdiFunctionImplicationsSimplified(f, state)
+        constraints should have size 15
+        constraints should contain { (f211 === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f111)) }
+        
+        constraints should contain { (f121 === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f111, f211)) }
+        constraints should contain { (f121 === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(f211)) }
+        
+        constraints should contain { (f221 === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f111, f211, f121)) }
+        constraints should contain { (f221 === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(f211, f121)) }
+        constraints should contain { (f221 === DE(7, B)) ==> (DE(6, B) equalsOneOfFlip Seq(f121)) }
+        
+        constraints should contain { (f112 === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f111, f211, f121, f221)) }
+        constraints should contain { (f112 === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(f211, f121, f221)) }
+        constraints should contain { (f112 === DE(7, B)) ==> (DE(6, B) equalsOneOfFlip Seq(f121, f221)) }
+        constraints should contain { (f112 === DE(8, B)) ==> (DE(7, B) equalsOneOfFlip Seq(f221)) }
+        
+        constraints should contain { (f212 === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f111, f211, f121, f221, f112)) }
+        constraints should contain { (f212 === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(f211, f121, f221, f112)) }
+        constraints should contain { (f212 === DE(7, B)) ==> (DE(6, B) equalsOneOfFlip Seq(f121, f221, f112)) }
+        constraints should contain { (f212 === DE(8, B)) ==> (DE(7, B) equalsOneOfFlip Seq(f221, f112)) }
+        constraints should contain { (f212 === DE(9, B)) ==> (DE(8, B) equalsOneOfFlip Seq(f112)) }
+    }
+
+    test("rdi Unary - Equalities (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, B)
+
+        val usedResultValues = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 1, 4, 6, 7
+
+        val scopes = Map(A -> 8, B -> 7)
+        val used = Map(B -> usedResultValues)
+        val state = StalenessState(Set(A, B), scopes, used)
+
+        val f1A = for (i <- Seq(2, 3, 5, 1)) yield {
+            App("f", DE(1, A)) === DE(i, B)
+        }
+        val f2A = for (i <- Seq(2, 3, 5, 1, 4)) yield {
+            App("f", DE(2, A)) === DE(i, B)
+        }
+        val f3A = for (i <- Seq(2, 3, 5, 1, 4, 6)) yield {
+            App("f", DE(3, A)) === DE(i, B)
+        }
+
+        SymmetryDL.rdiFunctionRangeRestrictions(f, state, Some(6)) map (_.asFormula) should be(
+            Set(
+                OrList(f1A),
+                OrList(f2A),
+                OrList(f3A)
+            )
+        )
+    }
+
+    test("rdi Ternary - Equalities (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, D, A, B)
+
+        val usedResultValues = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 1, 4, 6, 7, 8, 9
+
+        val scopes = Map(A -> 2, D -> 2, B -> 9)
+        val used = Map(B -> usedResultValues)
+        val state = StalenessState(Set(A, D, B), scopes, used)
+
+        val f111 = for (i <- Seq(2, 3, 5, 1)) yield {
+            App("f", DE(1, A), DE(1, D), DE(1, A)) === DE(i, B)
+        }
+        val f211 = for (i <- Seq(2, 3, 5, 1, 4)) yield {
+            App("f", DE(2, A), DE(1, D), DE(1, A)) === DE(i, B)
+        }
+        val f121 = for (i <- Seq(2, 3, 5, 1, 4, 6)) yield {
+            App("f", DE(1, A), DE(2, D), DE(1, A)) === DE(i, B)
+        }
+
+        val constraints = SymmetryDL.rdiFunctionRangeRestrictions(f, state, Some(6)) map (_.asFormula)
+        constraints should have size 3
+        constraints should contain(OrList(f111))
+        constraints should contain(OrList(f211))
+        constraints should contain(OrList(f121))
+    }
+
+    test("rdi Unary - Implications, Simplified (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, B)
+
+        val usedResultValues = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 1, 4, 6, 7
+
+        val scopes: Map[Sort, Int] = Map(A -> 8, B -> 7)
+        val used = Map(B -> usedResultValues)
+        val state = StalenessState(Set(A, B), scopes, used)
+
+        val f1A = App("f", DE(1, A))
+        val f2A = App("f", DE(2, A))
+        val f3A = App("f", DE(3, A))
+
+        val constraints = SymmetryDL.rdiFunctionImplicationsSimplified(f, state, 3)
+
+        constraints should have size 3
+
+        constraints should contain {
+            (f2A === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f1A))
+        }
+
+        constraints should contain {
+            (f3A === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f1A, f2A))
+        }
+        constraints should contain {
+            (f3A === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(f2A))
+        }
+    }
+
+    test("rdi Ternary - Implications, Simplified (With Disjuncts Limit)") {
+        val f = FuncDecl("f", A, D, A, B)
+
+        val usedResultValues = IndexedSeq(
+            DE(2, B),
+            DE(3, B),
+            DE(5, B),
+        ) // Unused: 1, 4, 6, 7, 8, 9
+
+        val scopes = Map(A -> 2, D -> 2, B -> 9)
+        val used = Map(B -> usedResultValues)
+        val state = StalenessState(Set(A, D, B), scopes, used)
+
+        val f111 = App("f", DE(1, A), DE(1, D), DE(1, A))
+        val f211 = App("f", DE(2, A), DE(1, D), DE(1, A))
+        val f121 = App("f", DE(1, A), DE(2, D), DE(1, A))
+        val f221 = App("f", DE(2, A), DE(2, D), DE(1, A))
+
+        val constraints = SymmetryDL.rdiFunctionImplicationsSimplified(f, state, 3)
+        constraints should have size 3
+        constraints should contain {
+            (f211 === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f111))
+        }
+
+        constraints should contain {
+            (f121 === DE(4, B)) ==> (DE(1, B) equalsOneOfFlip Seq(f111, f211))
+        }
+        constraints should contain {
+            (f121 === DE(6, B)) ==> (DE(4, B) equalsOneOfFlip Seq(f211))
+        }
+    }
+}

--- a/debug/src/main/scala/FortressDebug.scala
+++ b/debug/src/main/scala/FortressDebug.scala
@@ -80,6 +80,8 @@ object FortressDebug {
                     case "v2si" => new FortressTWO_SI
                     case "v3" => new FortressTHREE
                     case "v3si" => new FortressTHREE_SI
+                    case "v4" => new FortressFOUR
+                    case "v4si" => new FortressFOUR_SI
                     case "upperIter" => new IterativeUpperBoundModelFinder
                     case "parIter" => new ParallelIterativeUpperBoundModelFinder
                     case "upperND" => new NonDistUpperBoundModelFinder


### PR DESCRIPTION
1. Remove the second round of typechecking & sanitize in v2si
2. New symmetry breaking transformer with disjuncts limit and most used order
-  profiling
      - count the number of occurrences of all constants and function declarations
      - implemented as a theory operation to be called in the new symmetry breaking transformer
3. We added a new set of symmetry breaking code and possibly in the future we can integrate all the existing versions of symmetry breaking into the new code.



New symmetry breaking code organization: 
- Remaining Identifiers tracker (generic)
    - modified by breaker
    - read by selection heuristic
- Staleness tracker (generic)
    - what DEs can still be used (generic for all symmetry breaking schemes)
    - modified by breaker
    - read by selection heuristic
- breaker (generic) / factory
    - state: point to staleness tracker, remaining
    - store constraints
    - Adding the symmetry constraints → does different things depending on if constant or RDI/RDD function or predicate;  stores the new constraints and adds them to the theory at the end; takes list of constants and adds implications for constants; marks stale values (generic for all symmetry breaking schemes); 
    - modifies the stalenesstracker and remaining
    - depends on the disj limit
    -  called by the transformer
- selection heuristic (many options)
    - state: point to staleness tracker, remaining, and anything else (such as preplanned order), what’s been tried
    - reads staleness tracker, remaining
    - decides what to break on next: 
        - list of constants (in order)
        - or one fcn/pred
    - could be done on the on-the-fly (may need staleness info) or could be done in a preplanned order
    - called by transformer
    - the selection heuristic may put forward identifiers to  break and the constraints cannot be created for some reason (e.g., disj limit) and so those identifiers are still in the renaming list
    - how does it stop?
        - preplanned → stop at the end of the list; it would ignore staleness tracker and remaining list
        - greedy → infinite loop possible b/c disj limit → could be values left → only goes again on ones that have not been tried
- top-level symmetry breaking transformer (generic)
    - initialize staleness tracker
    - initialize trackremaining
    - initialize breaker(staleness tracker, trackremaining)
    - initialize the selection heuristic(staleness tracker, trackremaining) (e.g. with a preplanned order or do nothing)
    - selection heuristic is not passed any args b/c it can look up info in the stalenesstracker and trackrenaming)
    - iterates:
        - get the next thing to break on 
            - gets lists of constants all at once from heuristic so doesn’t have to collect constants
        - call the breaker to create the symmetry breaking constraints
        - if nothing to break on → stop
    - get the constraints from the breaker to add to the theory