### PR TITLE
Change illegal names and undoing this change for interpretation

### DIFF
--- a/core/src/main/scala/fortress/inputs/TptpToFortress.java
+++ b/core/src/main/scala/fortress/inputs/TptpToFortress.java
@@ -140,8 +140,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
     public Term visitForall(FOFTPTPParser.ForallContext ctx) {
         List<AnnotatedVar> variables = new ArrayList<>();
         for(TerminalNode variableNode: ctx.ID()) {
-            // add suffix “aa” to avoid illegal variable name
-            String name = variableNode.getText() + "aa";
+            String name = variableNode.getText();
             variables.add(Term.mkVar(name).of(universeSort));
         }
         Term body = (Term) visit(ctx.fof_formula());
@@ -152,8 +151,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
     public Term visitExists(FOFTPTPParser.ExistsContext ctx) {
         List<AnnotatedVar> variables = new ArrayList<>();
         for (TerminalNode variableNode: ctx.ID()) {
-            // add suffix “aa” to avoid illegal variable name
-            String name = variableNode.getText() + "aa";
+            String name = variableNode.getText();
             variables.add(Term.mkVar(name).of(universeSort));
         }
         Term body = (Term) visit(ctx.fof_formula());
@@ -204,8 +202,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitProp(FOFTPTPParser.PropContext ctx) {
-        // add suffix “aa” to avoid illegal variable name
-        String name = ctx.ID().getText() + "aa";
+        String name = ctx.ID().getText();
         Var v = Term.mkVar(name);
         primePropositions.add(v);
         return v;
@@ -223,8 +220,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitPred(FOFTPTPParser.PredContext ctx) {
-        // add suffix “aa” to avoid illegal function name
-        String name = ctx.ID().getText() + "aa";
+        String name = ctx.ID().getText();
         int numArgs = ctx.term().size();
 
         List<Sort> argSorts = new ArrayList<>();
@@ -249,15 +245,13 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitConVar(FOFTPTPParser.ConVarContext ctx) {
-        // add suffix “aa” to avoid illegal variable name
-        String name = ctx.ID().getText() + "aa";
+        String name = ctx.ID().getText();
         return Term.mkVar(name);
     }
 
     @Override
     public Term visitApply(FOFTPTPParser.ApplyContext ctx) {
-        // add suffix “aa” to avoid illegal function name
-        String name = ctx.ID().getText() + "aa";
+        String name = ctx.ID().getText();
         int numArgs = ctx.term().size();
         
         List<Sort> argSorts = new ArrayList<>();

--- a/core/src/main/scala/fortress/msfol/Declaration.scala
+++ b/core/src/main/scala/fortress/msfol/Declaration.scala
@@ -11,7 +11,6 @@ sealed trait Declaration
 /** A function declaration, including name, argument sorts, and result sort. */
 case class FuncDecl private (name: String, argSorts: Seq[Sort], resultSort: Sort) extends Declaration {
     Errors.Internal.precondition(argSorts.size > 0, "Cannot create nullary functions; use a constant instead")
-    Errors.Internal.precondition(! Names.isIllegal(name), "Illegal function name " + name)
     Errors.Internal.precondition(name.length > 0, "Cannot create function with empty name")
     
     /** The number of argument sorts. */

--- a/core/src/main/scala/fortress/msfol/Term.scala
+++ b/core/src/main/scala/fortress/msfol/Term.scala
@@ -55,7 +55,6 @@ extends ConcreteFactory[Var, String]((name: String) => new Var(name))
 with Caching[Var, String] {
 
     def apply(name: String): Var = {
-        Errors.Internal.precondition(! Names.isIllegal(name), "Illegal variable name " + name)
         create(name)
     }
     

--- a/core/src/main/scala/fortress/operations/IllegalNameSubstitution.scala
+++ b/core/src/main/scala/fortress/operations/IllegalNameSubstitution.scala
@@ -1,0 +1,82 @@
+package fortress.operations
+
+import scala.language.implicitConversions
+import fortress.msfol._
+
+import scala.collection.mutable
+
+
+case class IllegalNameSubstitution(affix: String) {
+    def newName(name: String): String = affix + name + affix
+
+    // Replace all illegal names in a Term, and updating the map.
+    def apply(term: Term, renameMap: mutable.Map[String, String]): Term = term match {
+        case Var(name) =>
+            // If it has been renamed before, we rename it to the same new name as before
+            if (renameMap.contains(name)) Var(renameMap(name))
+            // if it collides with some new names we introduced, we rename it to something else
+            else if (renameMap.valuesIterator.exists(_.equals(name)) || Names.isIllegal(name)) {
+                renameMap += name -> newName(name)
+                Var(renameMap(name))
+            } else term
+        case Top | Bottom => term
+        case Not(p) => Not(apply(p, renameMap))
+        case AndList(args) => AndList(args map (arg => apply(arg, renameMap)))
+        case OrList(args) => OrList(args map (arg => apply(arg, renameMap)))
+        case Distinct(args) => Distinct(args map (arg => apply(arg, renameMap)))
+        case Implication(p, q) => Implication(apply(p, renameMap), apply(q, renameMap))
+        case Iff(p, q) => Iff(apply(p, renameMap), apply(q, renameMap))
+        case Eq(l, r) => Eq(apply(l, renameMap), apply(r, renameMap))
+        case App(name, args) => App(renameMap.getOrElse(name, name), args map (arg => apply(arg, renameMap)))
+        case Closure(name, args, arg1, arg2) => Closure(renameMap.getOrElse(name, name), args map (arg => apply(arg, renameMap)), apply(arg1, renameMap), apply(arg2, renameMap))
+        case ReflexiveClosure(name, args, arg1, arg2) => ReflexiveClosure(renameMap.getOrElse(name, name), args map (arg => apply(arg, renameMap)), apply(arg1, renameMap), apply(arg2, renameMap))
+        case Exists(avars, body) =>
+            val newVars = avars map { avar => Var(renameMap.getOrElse(avar.name, avar.name)) of avar.sort }
+            Exists(newVars, apply(body, renameMap))
+        case Forall(avars, body) =>
+            val newVars = avars map { avar => Var(renameMap.getOrElse(avar.name, avar.name)) of avar.sort }
+            Forall(newVars, apply(body, renameMap))
+        case DomainElement(index, sort) => term
+        case EnumValue(_) | BuiltinApp(_, _) | IntegerLiteral(_) | BitVectorLiteral(_, _) => term
+        case IfThenElse(condition, ifTrue, ifFalse) => IfThenElse(apply(condition, renameMap), apply(ifTrue, renameMap), apply(ifFalse, renameMap))
+    }
+
+    // Replace all illegal names in a Signature, and updating the map.
+    def apply(signature: Signature, renameMap: mutable.Map[String, String]): Signature = signature match {
+        case Signature(sorts, functionDeclarations, constants, enumConstants) => {
+            val newConstants = constants map { constant =>
+                if (renameMap.contains(constant.name)) {
+                    // If it has been renamed already, we simply rename it as before
+                    AnnotatedVar(Var(renameMap(constant.name)), constant.sort)
+                } else if (renameMap.valuesIterator.exists(_.equals(constant.name)) || Names.isIllegal(constant.name)) {
+                    // If it is an illegal name, we rename it and added to the map
+                    renameMap += constant.name -> newName(constant.name)
+                    AnnotatedVar(Var(renameMap(constant.name)), constant.sort)
+                } else constant
+            }
+            val newFunctions = functionDeclarations map { funcDecl =>
+                if (renameMap.contains(funcDecl.name)) {
+                    // If it has been renamed already, we simply rename it as before
+                    FuncDecl(renameMap(funcDecl.name), funcDecl.argSorts, funcDecl.resultSort)
+                } else if (renameMap.valuesIterator.exists(_.equals(funcDecl.name)) || Names.isIllegal(funcDecl.name)) {
+                    // If it is an illegal name, we rename it and added to the map
+                    renameMap += funcDecl.name -> newName(funcDecl.name)
+                    FuncDecl(renameMap(funcDecl.name), funcDecl.argSorts, funcDecl.resultSort)
+                } else funcDecl
+            }
+
+            Signature(
+                sorts,
+                newFunctions,
+                newConstants,
+                enumConstants
+            )
+        }
+    }
+
+    // Replace all illegal names in a Theory, and updating the map.
+    def apply(theory: Theory, renameMap: mutable.Map[String, String]): Theory = {
+        Theory.mkTheoryWithSignature(apply(theory.signature, renameMap))
+          .withAxioms(theory.axioms map (axiom => apply(axiom, renameMap)))
+    }
+}

--- a/core/src/main/scala/fortress/transformers/TypecheckSanitizeTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/TypecheckSanitizeTransformer.scala
@@ -1,29 +1,41 @@
 package fortress.transformers
 
+import fortress.interpretation.Interpretation
 import fortress.msfol._
 import fortress.operations.TermOps._
 import fortress.operations.TheoryOps._
 import fortress.operations._
 import fortress.util.Errors
 
+import scala.collection.mutable
+
 /** Type-checks a theory, and performs sanitization (for example, replacing Equals of booleans with Iff).
   * Throws an exception if the theory does not type-check correctly.
   */
-object TypecheckSanitizeTransformer extends TheoryTransformer {
-    
-    override def apply(theory: Theory): Theory = {
+object TypecheckSanitizeTransformer extends ProblemStateTransformer {
 
-        def sanitizeAxiom(axiom: Term): Term = {
-            // Check axiom typechecks as bool
-            // Note that a formula cannot typecheck if it has any free variables (that are not constants of the signature)
-            val result: TypeCheckResult = axiom.typeCheck(theory.signature)
-            // System.out.println(axiom.toString + (result.sort).toString) ;
-            Errors.Internal.precondition(result.sort == BoolSort)
-            result.sanitizedTerm
+    override def apply(problemState: ProblemState): ProblemState = problemState match {
+        case ProblemState(theory, scopes, skc, skf, rangeRestricts, unapplyInterp) => {
+            // change illegal names by adding prefix "aa" and suffix "aa"
+            val affix = "aa"
+            val renameMap: mutable.Map[String, String] = mutable.Map.empty
+            var newTheory = IllegalNameSubstitution(affix).apply(theory, renameMap)
+
+            def sanitizeAxiom(axiom: Term): Term = {
+                // Check axiom typechecks as bool
+                // Note that a formula cannot typecheck if it has any free variables (that are not constants of the signature)
+                val result: TypeCheckResult = axiom.typeCheck(newTheory.signature)
+                // System.out.println(axiom.toString + (result.sort).toString) ;
+                Errors.Internal.precondition(result.sort == BoolSort)
+                result.sanitizedTerm
+            }
+
+            newTheory = newTheory.mapAxioms(t => sanitizeAxiom(t))
+
+            val unapply: Interpretation => Interpretation = _.applyNameSubstitution(renameMap.toMap)
+            ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapply :: unapplyInterp)
         }
-
-        theory.mapAxioms(t => sanitizeAxiom(t))
     }
-    
+
     override def name: String = "Typecheck & Sanitize Transformer"
 }

--- a/core/src/test/scala/inputs/TptpParserTest.scala
+++ b/core/src/test/scala/inputs/TptpParserTest.scala
@@ -23,29 +23,29 @@ class TptpParserTest extends UnitSuite {
         val resultTheory = (new TptpFofParser).parse(fileStream).getOrElse()
         val universeSort = Sort.mkSortConst("_UNIV")
 
-        val A = Var("Aaa")
-        val B = Var("Baa")
-        val C = Var("Caa")
-        val e = Var("eaa")
-        val f = FuncDecl.mkFuncDecl("faa", universeSort, universeSort, universeSort)
+        val A = Var("A")
+        val B = Var("B")
+        val C = Var("C")
+        val e = Var("e")
+        val f = FuncDecl.mkFuncDecl("f", universeSort, universeSort, universeSort)
 
         val associative = Forall(Seq(A.of(universeSort), B.of(universeSort), C.of(universeSort)),
             Eq(
-                App("faa", App("faa", A, B), C),
-                App("faa", A, App("faa", B, C))))
+                App("f", App("f", A, B), C),
+                App("f", A, App("f", B, C))))
 
         val identity = Forall(A.of(universeSort),
             And(
-                Eq(App("faa", A, e), A),
-                Eq(App("faa", e, A), A)))
+                Eq(App("f", A, e), A),
+                Eq(App("f", e, A), A)))
 
         val inverse = Forall(A.of(universeSort), Exists(B.of(universeSort),
             And(
-                Eq(App("faa", A, B), e),
-                Eq(App("faa", B, A), e))))
+                Eq(App("f", A, B), e),
+                Eq(App("f", B, A), e))))
 
         val notAbelian = Not(Forall(Seq(A.of(universeSort), B.of(universeSort)),
-            Eq(App("faa", A, B), App("faa", B, A))))
+            Eq(App("f", A, B), App("f", B, A))))
 
         val expectedTheory = Theory.empty
           .withSort(universeSort)
@@ -141,7 +141,7 @@ class TptpParserTest extends UnitSuite {
         val resultTheory = (new TptpFofParser).parse(inputStream).getOrElse()
         val universeSort = Sort.mkSortConst("_UNIV")
 
-        val a = Var("a" + "aa")
+        val a = Var("a")
         val axiom1 = And(Implication(Eq(a, a), Top), Implication(Bottom, Eq(a, a)))
 
         val expectedTheory = Theory.empty


### PR DESCRIPTION
As a followup to PR #27,
- Remove the illegal names check from the theory
- Changing illegal names (and then undoing this change for interpretations using the "unapply") in the type-checking transformer