### PR TITLE
Changed all identifier names at time of convertion to SMT-LIB

### DIFF
--- a/DevelopersGuide.md
+++ b/DevelopersGuide.md
@@ -218,7 +218,7 @@ Operations are:
 - Simplification: some simple simplifications (not true == false, two domain elements are not equal) @Joe - this is where Khadija's simplifications would be added I think.
 - SimplificationWithRange: like the above, but range restrictions are passed as an argument and used to simplify formulas. @Joe - aren't range formulas mostly going to be disjunctions? how does this help with simplifications?
 - Skolemization: skolemizes a term, which produces a new term, skolem constants and functions.
-- SmtlibConversion: converts a term to the strings needed for SMT-LIB.
+- SmtlibConversion: converts a term to the strings needed for SMT-LIB. We add suffixes "aa" to all variable and function names when converting to SMT-LIB to avoid having reserved keywords as identifiers. And when reading the results, we remove all the suffixes added.
 - Substitution: substitutes a term for a variable in a term.  Performs needed alpha-renaming to avoid variable capture. FastSubstitutor does a bunch of substitutions in parallel.
 - TermConvertor: Converts Ints to Signed Bit Vector operations. @Joe - perhaps this file should be renamed to be more specific to ints?
 - TermMetrics: various metrics on terms (depth of quantification, depth of nested functions, number of nodes in a term)

--- a/core/src/main/scala/fortress/inputs/TptpToFortress.java
+++ b/core/src/main/scala/fortress/inputs/TptpToFortress.java
@@ -140,8 +140,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
     public Term visitForall(FOFTPTPParser.ForallContext ctx) {
         List<AnnotatedVar> variables = new ArrayList<>();
         for(TerminalNode variableNode: ctx.ID()) {
-            // add suffix “aa” to avoid illegal variable name
-            String name = variableNode.getText() + "aa";
+            String name = variableNode.getText();
             variables.add(Term.mkVar(name).of(universeSort));
         }
         Term body = (Term) visit(ctx.fof_formula());
@@ -152,8 +151,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
     public Term visitExists(FOFTPTPParser.ExistsContext ctx) {
         List<AnnotatedVar> variables = new ArrayList<>();
         for (TerminalNode variableNode: ctx.ID()) {
-            // add suffix “aa” to avoid illegal variable name
-            String name = variableNode.getText() + "aa";
+            String name = variableNode.getText();
             variables.add(Term.mkVar(name).of(universeSort));
         }
         Term body = (Term) visit(ctx.fof_formula());
@@ -204,8 +202,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitProp(FOFTPTPParser.PropContext ctx) {
-        // add suffix “aa” to avoid illegal variable name
-        String name = ctx.ID().getText() + "aa";
+        String name = ctx.ID().getText();
         Var v = Term.mkVar(name);
         primePropositions.add(v);
         return v;
@@ -223,8 +220,7 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitPred(FOFTPTPParser.PredContext ctx) {
-        // add suffix “aa” to avoid illegal function name
-        String name = ctx.ID().getText() + "aa";
+        String name = ctx.ID().getText();
         int numArgs = ctx.term().size();
 
         List<Sort> argSorts = new ArrayList<>();
@@ -249,15 +245,13 @@ public class TptpToFortress extends FOFTPTPBaseVisitor {
 
     @Override
     public Term visitConVar(FOFTPTPParser.ConVarContext ctx) {
-        // add suffix “aa” to avoid illegal variable name
-        String name = ctx.ID().getText() + "aa";
+        String name = ctx.ID().getText();
         return Term.mkVar(name);
     }
 
     @Override
     public Term visitApply(FOFTPTPParser.ApplyContext ctx) {
-        // add suffix “aa” to avoid illegal function name
-        String name = ctx.ID().getText() + "aa";
+        String name = ctx.ID().getText();
         int numArgs = ctx.term().size();
         
         List<Sort> argSorts = new ArrayList<>();

--- a/core/src/main/scala/fortress/msfol/Names.scala
+++ b/core/src/main/scala/fortress/msfol/Names.scala
@@ -1,20 +1,25 @@
 package fortress.msfol
 
-/** Stores and tests for illegal names. */ 
+/** Stores and tests for illegal names. */
 object Names {
-    private val illegalNames: Set[String] = Set(
-        "and", "or", "not", "=>", "<=>", "iff",
-        "forall", "exists", "=", "==",
-        "true", "false", 
-        "if", "else"
-    )
-    
+    private val illegalNames: Set[String] = Set.empty
+    /**
+      * SMT-LIB reserved keywords: "and", "or", "not", "=>", "<=>", "iff",
+      * "forall", "exists", "=", "==", "true", "false", "if", "else"
+      * The reason we can't use those names is that when we output the SMT-LIB
+      * string, the SMT solver would be confused if we have a variable named
+      * e.g. "not" that wasn't meant to be the logical not operation.
+      *
+      * But now we are adding suffix to all variable, function names when
+      * converting to SMT-LIB, so this is no longer a problem.
+      */
+
+
     private val illegalPrefixes: Set[String] = Set(
         DomainElement.prefix,
         "@",
         "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"
     )
-    
-    def isIllegal(name: String): Boolean =
-        (illegalNames contains name.toLowerCase) || (illegalPrefixes exists (name startsWith _))
+
+    def isIllegal(name: String): Boolean = illegalPrefixes exists (name startsWith _)
 }

--- a/core/src/main/scala/fortress/operations/SmtlibConversion.scala
+++ b/core/src/main/scala/fortress/operations/SmtlibConversion.scala
@@ -2,8 +2,10 @@ package fortress.operations
 
 import fortress.msfol._
 import fortress.util.Errors
+import fortress.util.NameConverter._
 
 class SmtlibConverter(writer: java.io.Writer) {
+
     // Use a writer for efficiency
     def write(t: Term): Unit = {
         def recur(term: Term): Unit = term match {
@@ -12,7 +14,7 @@ class SmtlibConverter(writer: java.io.Writer) {
             // case d @ DomainElement(index, sort) => writer.write(d.asSmtConstant.name)
             case Top => writer.write("true")
             case Bottom => writer.write("false")
-            case Var(name) => writer.write(name)
+            case Var(name) => writer.write(nameWithAffix(name))
             case Not(p) => writeGeneralApp("not", Seq(p))
             case AndList(args) => writeGeneralApp("and", args)
             case OrList(args) => writeGeneralApp("or", args)
@@ -20,7 +22,7 @@ class SmtlibConverter(writer: java.io.Writer) {
             case Implication(left, right) => writeGeneralApp("=>", Seq(left, right))
             case Iff(left, right) => writeGeneralApp("=", Seq(left, right))
             case Eq(left, right) => writeGeneralApp("=", Seq(left, right))
-            case App(fname, args) => writeGeneralApp(fname, args)
+            case App(fname, args) => writeGeneralApp(nameWithAffix(fname), args)
             case IfThenElse(condition, ifTrue, ifFalse) => writeGeneralApp("ite", Seq(condition, ifTrue, ifFalse))
             case Exists(vars, body) => {
                 writer.write("(exists (")
@@ -30,7 +32,7 @@ class SmtlibConverter(writer: java.io.Writer) {
                         writer.write(' ')
                     }
                     writer.write('(')
-                    writer.write(av.name)
+                    writer.write(nameWithAffix(av.name))
                     writer.write(' ')
                     writeSort(av.sort)
                     writer.write(')')
@@ -48,7 +50,7 @@ class SmtlibConverter(writer: java.io.Writer) {
                         writer.write(' ')
                     }
                     writer.write('(')
-                    writer.write(av.name)
+                    writer.write(nameWithAffix(av.name))
                     writer.write(' ')
                     writeSort(av.sort)
                     writer.write(')')
@@ -149,7 +151,7 @@ class SmtlibConverter(writer: java.io.Writer) {
     
     def writeFuncDecl(funcDecl: FuncDecl): Unit = {
         writer.write("(declare-fun ")
-        writer.write(funcDecl.name)
+        writer.write(nameWithAffix(funcDecl.name))
         writer.write(" (")
         writeSorts(funcDecl.argSorts)
         writer.write(") ")
@@ -159,7 +161,7 @@ class SmtlibConverter(writer: java.io.Writer) {
     
     def writeConst(constant: AnnotatedVar): Unit = {
         writer.write("(declare-const ")
-        writer.write(constant.name)
+        writer.write(nameWithAffix(constant.name))
         writer.write(' ')
         writeSort(constant.sort)
         writer.write(')')

--- a/core/src/main/scala/fortress/solverinterface/ProcessSmtlibEvaluation.scala
+++ b/core/src/main/scala/fortress/solverinterface/ProcessSmtlibEvaluation.scala
@@ -38,10 +38,13 @@ trait ProcessSmtlibEvaluation extends ProcessBuilderSolver {
             
             override protected def evaluateFunction(f: FuncDecl, argList: Seq[Value]): Value = {
                 processSession.get.write("(get-value ((")
-                processSession.get.write(f.name)
+                processSession.get.write(NameConverter.nameWithAffix(f.name))
                 for(arg <- argList){
                     processSession.get.write(" ")
-                    processSession.get.write(arg.toString)
+                    if (arg.toString.equals("true") || arg.toString.equals("false"))
+                        processSession.get.write(arg.toString)
+                    else
+                        processSession.get.write(NameConverter.nameWithAffix(arg.toString))
                 }
                 processSession.get.write(")))")
                 processSession.get.write("\n")
@@ -63,11 +66,11 @@ trait ProcessSmtlibEvaluation extends ProcessBuilderSolver {
         }
         Solution
     }
-    
+
     private def getFortressNameToSmtValueMap(theory: Theory): Map[String, String] = {
         for(constant <- theory.constants){
             processSession.get.write("(get-value (")
-            processSession.get.write(constant.name)
+            processSession.get.write(NameConverter.nameWithAffix(constant.name))
             processSession.get.write("))")
         }
         processSession.get.write("\n")
@@ -77,7 +80,7 @@ trait ProcessSmtlibEvaluation extends ProcessBuilderSolver {
             val str = processSession.get.readLine()
             str match {
                 case ProcessBuilderSolver.smt2Model(name, value) => {
-                    Errors.Internal.assertion(constant.name == name, s""""${constant.name}" should be equal to "$name"""")
+                    Errors.Internal.assertion(constant.name == NameConverter.nameWithoutAffix(name), s""""${constant.name}" should be equal to "${NameConverter.nameWithoutAffix(name)}"""")
                     (constant.name -> value)
                 }
                 case _ => Errors.Internal.impossibleState

--- a/core/src/main/scala/fortress/util/NameConverter.scala
+++ b/core/src/main/scala/fortress/util/NameConverter.scala
@@ -1,0 +1,14 @@
+package fortress.util
+
+/** We add affixes to all variable and function names when converting to SMT-LIB
+  * to avoid having reserved keywords as identifiers
+  */
+object NameConverter {
+    // Function to add affixes to name
+    def nameWithAffix(name: String): String = name + "aa"
+
+    // Function to remove affixes from name
+    def nameWithoutAffix(name: String): String =
+        if (name.endsWith("aa")) name.substring(0, name.length - 2)
+        else name
+}

--- a/core/src/test/scala/inputs/TptpParserTest.scala
+++ b/core/src/test/scala/inputs/TptpParserTest.scala
@@ -23,29 +23,29 @@ class TptpParserTest extends UnitSuite {
         val resultTheory = (new TptpFofParser).parse(fileStream).getOrElse()
         val universeSort = Sort.mkSortConst("_UNIV")
 
-        val A = Var("Aaa")
-        val B = Var("Baa")
-        val C = Var("Caa")
-        val e = Var("eaa")
-        val f = FuncDecl.mkFuncDecl("faa", universeSort, universeSort, universeSort)
+        val A = Var("A")
+        val B = Var("B")
+        val C = Var("C")
+        val e = Var("e")
+        val f = FuncDecl.mkFuncDecl("f", universeSort, universeSort, universeSort)
 
         val associative = Forall(Seq(A.of(universeSort), B.of(universeSort), C.of(universeSort)),
             Eq(
-                App("faa", App("faa", A, B), C),
-                App("faa", A, App("faa", B, C))))
+                App("f", App("f", A, B), C),
+                App("f", A, App("f", B, C))))
 
         val identity = Forall(A.of(universeSort),
             And(
-                Eq(App("faa", A, e), A),
-                Eq(App("faa", e, A), A)))
+                Eq(App("f", A, e), A),
+                Eq(App("f", e, A), A)))
 
         val inverse = Forall(A.of(universeSort), Exists(B.of(universeSort),
             And(
-                Eq(App("faa", A, B), e),
-                Eq(App("faa", B, A), e))))
+                Eq(App("f", A, B), e),
+                Eq(App("f", B, A), e))))
 
         val notAbelian = Not(Forall(Seq(A.of(universeSort), B.of(universeSort)),
-            Eq(App("faa", A, B), App("faa", B, A))))
+            Eq(App("f", A, B), App("f", B, A))))
 
         val expectedTheory = Theory.empty
           .withSort(universeSort)
@@ -141,7 +141,7 @@ class TptpParserTest extends UnitSuite {
         val resultTheory = (new TptpFofParser).parse(inputStream).getOrElse()
         val universeSort = Sort.mkSortConst("_UNIV")
 
-        val a = Var("a" + "aa")
+        val a = Var("a")
         val axiom1 = And(Implication(Eq(a, a), Top), Implication(Bottom, Eq(a, a)))
 
         val expectedTheory = Theory.empty

--- a/core/src/test/scala/operations/SmtlibConversionTests.scala
+++ b/core/src/test/scala/operations/SmtlibConversionTests.scala
@@ -23,15 +23,15 @@ class SmtlibConversionTests extends UnitSuite {
         val formula3 = Exists(x of A, Forall(y of B, Distinct(x, x) or App("P", x, y)))
         val formula4 = And(Top, Bottom, q, r)
         
-        formula1.smtlib should be ("(forall ((x A) (y B)) (= (f x) y))")
-        formula2.smtlib should be ("(or (and (=> q r) (=> r q)) (= (not r) q))")
-        formula3.smtlib should be ("(exists ((x A)) (forall ((y B)) (or (distinct x x) (P x y))))")
-        formula4.smtlib should be ("(and true false q r)")
+        formula1.smtlib should be ("(forall ((xaa A) (yaa B)) (= (faa xaa) yaa))")
+        formula2.smtlib should be ("(or (and (=> qaa raa) (=> raa qaa)) (= (not raa) qaa))")
+        formula3.smtlib should be ("(exists ((xaa A)) (forall ((yaa B)) (or (distinct xaa xaa) (Paa xaa yaa))))")
+        formula4.smtlib should be ("(and true false qaa raa)")
     }
     
     test("basic assertion") {
          val formula1 = Forall(Seq(x of A, y of B), App("f", x) === y)
-         formula1.smtlibAssertion should be ("(assert (forall ((x A) (y B)) (= (f x) y)))")
+         formula1.smtlibAssertion should be ("(assert (forall ((xaa A) (yaa B)) (= (faa xaa) yaa)))")
     }
     
     test("integer conversion") {
@@ -45,7 +45,7 @@ class SmtlibConversionTests extends UnitSuite {
             BuiltinApp(IntMult, x, y) === prime
         )))
         
-        formula.smtlibAssertion should be ("(assert (not (exists ((x Int) (y Int)) (and (> x 1) (> y 1) (= (* x y) prime)))))")
+        formula.smtlibAssertion should be ("(assert (not (exists ((xaa Int) (yaa Int)) (and (> xaa 1) (> yaa 1) (= (* xaa yaa) primeaa)))))")
     }
 
     test("basic theory") {
@@ -57,11 +57,11 @@ class SmtlibConversionTests extends UnitSuite {
 
         theory.smtlib should be ("(declare-sort A 0)" +
                                 "(declare-sort B 0)" +
-                                "(declare-fun f (A) B)" +
-                                "(declare-fun P (A B) Bool)" +
-                                "(declare-const x A)" +
-                                "(declare-const y B)" +
-                                "(assert (P x y))")
+                                "(declare-fun faa (A) B)" +
+                                "(declare-fun Paa (A B) Bool)" +
+                                "(declare-const xaa A)" +
+                                "(declare-const yaa B)" +
+                                "(assert (Paa xaa yaa))")
     }
     
     test("basic sorts") {


### PR DESCRIPTION
As a followup to PR #27,
- Remove the illegal names check from the theory
- change ALL identifier names with a suffix at time of conversion to SMT and then for the instance returned change all names back (so renaming is not specific to the theory/problem state therefore “unapply” can be done for all problems, plus error messages from earlier in the transformers still make sense in terms of original names)