### PR TITLE
Convert instance back for the predicates subset method

### DIFF
--- a/core/src/main/scala/fortress/compiler/FortressCompilers.scala
+++ b/core/src/main/scala/fortress/compiler/FortressCompilers.scala
@@ -16,13 +16,13 @@ abstract class BaseFortressCompiler(integerSemantics: IntegerSemantics) extends 
         val transformerSequence = new scala.collection.mutable.ListBuffer[ProblemStateTransformer]
         transformerSequence += TypecheckSanitizeTransformer
         transformerSequence += EnumEliminationTransformer
-        integerSemantics match {
-            case Unbounded => ()
-            case ModularSigned(bitwidth) => {
-                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
-            }
-        }
-        transformerSequence += ClosureEliminationTransformer
+//        integerSemantics match {
+//            case Unbounded => ()
+//            case ModularSigned(bitwidth) => {
+//                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
+//            }
+//        }
+//        transformerSequence += ClosureEliminationTransformer
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
         transformerSequence ++= symmetryBreakingTransformers
@@ -61,12 +61,12 @@ class FortressTWOCompiler_SI(integerSemantics: IntegerSemantics) extends LogicCo
         val transformerSequence = new scala.collection.mutable.ListBuffer[ProblemStateTransformer]
         transformerSequence += TypecheckSanitizeTransformer
         transformerSequence += EnumEliminationTransformer
-        integerSemantics match {
-            case Unbounded => ()
-            case ModularSigned(bitwidth) => {
-                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
-            }
-        }
+//        integerSemantics match {
+//            case Unbounded => ()
+//            case ModularSigned(bitwidth) => {
+//                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
+//            }
+//        }
         transformerSequence += SortInferenceTransformer
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
@@ -106,12 +106,12 @@ class FortressFOURCompiler_SI(integerSemantics: IntegerSemantics) extends LogicC
         val transformerSequence = new scala.collection.mutable.ListBuffer[ProblemStateTransformer]
         transformerSequence += TypecheckSanitizeTransformer
         transformerSequence += EnumEliminationTransformer
-        integerSemantics match {
-            case Unbounded => ()
-            case ModularSigned(bitwidth) => {
-                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
-            }
-        }
+//        integerSemantics match {
+//            case Unbounded => ()
+//            case ModularSigned(bitwidth) => {
+//                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
+//            }
+//        }
         transformerSequence += SortInferenceTransformer
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
@@ -133,12 +133,12 @@ class FortressUnboundedCompiler(integerSemantics: IntegerSemantics) extends Base
         val transformerSequence = new scala.collection.mutable.ListBuffer[ProblemStateTransformer]
         transformerSequence += TypecheckSanitizeTransformer
         transformerSequence += EnumEliminationTransformer
-        integerSemantics match {
-            case Unbounded => ()
-            case ModularSigned(bitwidth) => {
-                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
-            }
-        }
+//        integerSemantics match {
+//            case Unbounded => ()
+//            case ModularSigned(bitwidth) => {
+//                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
+//            }
+//        }
         transformerSequence += TypecheckSanitizeTransformer
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
@@ -159,13 +159,13 @@ class FortressLearnedLiteralsCompiler(integerSemantics: IntegerSemantics) extend
         val transformerSequence = new scala.collection.mutable.ListBuffer[ProblemStateTransformer]
         transformerSequence += TypecheckSanitizeTransformer
         transformerSequence += EnumEliminationTransformer
-        integerSemantics match {
-            case Unbounded => ()
-            case ModularSigned(bitwidth) => {
-                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
-            }
-        }
-        transformerSequence += ClosureEliminationTransformer
+//        integerSemantics match {
+//            case Unbounded => ()
+//            case ModularSigned(bitwidth) => {
+//                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
+//            }
+//        }
+//        transformerSequence += ClosureEliminationTransformer
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
         transformerSequence ++= symmetryBreakingTransformers
@@ -187,6 +187,7 @@ class NonDistUpperBoundCompiler extends LogicCompiler {
     override def transformerSequence: Seq[ProblemStateTransformer] = {
         val transformerSequence = new scala.collection.mutable.ListBuffer[ProblemStateTransformer]
         transformerSequence += TypecheckSanitizeTransformer
+        transformerSequence += EnumEliminationTransformer
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
         transformerSequence ++= symmetryBreakingTransformers
@@ -208,6 +209,7 @@ class PredUpperBoundCompiler extends LogicCompiler {
         val transformerSequence = new scala.collection.mutable.ListBuffer[ProblemStateTransformer]
         transformerSequence += TypecheckSanitizeTransformer
         transformerSequence += new ScopeSubtypeTransformer // Must be before skolemization
+        transformerSequence += EnumEliminationTransformer
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
         transformerSequence ++= symmetryBreakingTransformers

--- a/core/src/main/scala/fortress/interpretation/Interpretation.scala
+++ b/core/src/main/scala/fortress/interpretation/Interpretation.scala
@@ -102,6 +102,15 @@ trait Interpretation {
         )
     }
 
+    /** Updates thr domain elements associated with specified sort. */
+    def updateSortInterpretations(sort: Sort, values: Seq[Value]): Interpretation = {
+        new BasicInterpretation(
+            sortInterpretations + (sort -> values),
+            constantInterpretations,
+            functionInterpretations
+        )
+    }
+
     /** Generates a set of constraints which says that an interpretation must agree
       * with this interpretation on all of the constants and functions present.
       */

--- a/core/src/main/scala/fortress/transformers/ScopeSubtypeTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/ScopeSubtypeTransformer.scala
@@ -1,40 +1,65 @@
 package fortress.transformers
 
+import fortress.interpretation.Interpretation
 import fortress.msfol._
 import fortress.operations._
 import fortress.operations.TheoryOps._
-class ScopeSubtypeTransformer extends TheoryTransformer {
-    
-    override def apply(theory: Theory): Theory =  {
-        val scopeSubtypePreds = theory.sorts.map(sort => {
-            val predName = ScopeSubtype.subtypePred(sort)
-            val predDecl = FuncDecl(predName, sort, BoolSort)
-            predDecl
-        })
 
-        // Have to say the subtypes are nonempty
-        val antiVacuityAxioms = theory.sorts.map(sort => Exists(Var("x") of sort, App(ScopeSubtype.subtypePred(sort), Var("x"))))
+class ScopeSubtypeTransformer extends ProblemStateTransformer {
 
-        // Constants and functions must have ranges in the subtypes
-        val constantAxioms = for (av <- theory.constants) yield App(ScopeSubtype.subtypePred(av.sort), av.variable)
-        val functionAxioms = for {
-            fdecl <- theory.functionDeclarations
-            if !fdecl.resultSort.isBuiltin
-        } yield {
+    override def apply(problemState: ProblemState): ProblemState = problemState match {
+        case ProblemState(theory, scopes, skc, skf, rangeRestricts, unapplyInterp) => {
+            val scopeSubtypePreds = theory.sorts.map(sort => {
+                val predName = ScopeSubtype.subtypePred(sort)
+                val predDecl = FuncDecl(predName, sort, BoolSort)
+                predDecl
+            })
 
-            val argsAnnotated = fdecl.argSorts.zipWithIndex.map{case (sort, index) => Var(s"x_${sort}_${index}") of sort}
-            val outputPred = ScopeSubtype.subtypePred(fdecl.resultSort)
-            // We don't need to check that the inputs are in the subtypes, such inputs don't have any affect on the formulas
-            Forall(argsAnnotated, App(outputPred, App(fdecl.name, argsAnnotated.map(_.variable))))
+            // Have to say the subtypes are nonempty
+            val antiVacuityAxioms = theory.sorts.map(sort => Exists(Var("x") of sort, App(ScopeSubtype.subtypePred(sort), Var("x"))))
+
+            // Constants and functions must have ranges in the subtypes
+            val constantAxioms = for (av <- theory.constants) yield App(ScopeSubtype.subtypePred(av.sort), av.variable)
+            val functionAxioms = for {
+                fdecl <- theory.functionDeclarations
+                if !fdecl.resultSort.isBuiltin
+            } yield {
+
+                val argsAnnotated = fdecl.argSorts.zipWithIndex.map { case (sort, index) => Var(s"x_${sort}_${index}") of sort }
+                val outputPred = ScopeSubtype.subtypePred(fdecl.resultSort)
+                // We don't need to check that the inputs are in the subtypes, such inputs don't have any affect on the formulas
+                Forall(argsAnnotated, App(outputPred, App(fdecl.name, argsAnnotated.map(_.variable))))
+            }
+
+            val resultTheory = theory
+              .withFunctionDeclarations(scopeSubtypePreds)
+              .mapAxioms(ScopeSubtype.addBoundsPredicates)
+              .withAxioms(antiVacuityAxioms)
+              .withAxioms(constantAxioms)
+              .withAxioms(functionAxioms)
+
+            val unapply: Interpretation => Interpretation = {
+                interp => {
+                    var resultInterp = interp
+                    for (pred <- scopeSubtypePreds) {
+                        val sort: Sort = pred.argSorts.head
+                        val domainElements: Seq[Value] = interp.functionInterpretations(pred).toSeq.filter(pred => pred._2 == Top).map(_._1.head)
+                        resultInterp = resultInterp.updateSortInterpretations(sort, domainElements)
+                    }
+                    resultInterp
+                }
+            }
+
+            ProblemState(
+                resultTheory,
+                scopes, skc,
+                skf,
+                rangeRestricts,
+                unapply :: unapplyInterp
+            )
         }
-
-        theory
-            .withFunctionDeclarations(scopeSubtypePreds)
-            .mapAxioms(ScopeSubtype.addBoundsPredicates)
-            .withAxioms(antiVacuityAxioms)
-            .withAxioms(constantAxioms)
-            .withAxioms(functionAxioms)
     }
-    
+
     override def name: String = "Scope Subtype Transformer"
+
 }

--- a/core/src/test/scala/operations/ScopeSubtypeTest.scala
+++ b/core/src/test/scala/operations/ScopeSubtypeTest.scala
@@ -1,0 +1,42 @@
+import org.scalatest._
+
+import fortress.msfol._
+import fortress.operations.ScopeSubtype
+import fortress.operations.TermOps._
+
+class ScopeSubtypeTest extends UnitSuite {
+
+    val A = Sort.mkSortConst("A")
+    val B = Sort.mkSortConst("B")
+
+    val x = Term.mkVar("x")
+    val y = Term.mkVar("y")
+    val z = Term.mkVar("z")
+    val a1 = Term.mkDomainElement(1, A)
+    val a2 = Term.mkDomainElement(2, A)
+
+    test("basic scope subtype") {
+        val t1 = AndList(App("f", y) ==> Top, x === App("f", y), Top)
+        val t2 = OrList(App("f", y) ==> Bottom, Not(App("f", y)), Bottom, Not(Top))
+
+        ScopeSubtype.addBoundsPredicates(t1) should be(t1)
+        ScopeSubtype.addBoundsPredicates(t2) should be(t2)
+    }
+
+    test("forall/exists scope subtype") {
+        val t1 = Forall(x of A, App("R", x))
+        val t2 = Forall(Seq(x of A, y of B), App("R", x))
+        val t3 = Exists(x of A, App("R", z))
+        val t4 = Exists(Seq(x of A, y of B), App("R", z))
+
+        val e1 = Forall(x of A, App(ScopeSubtype.subtypePred(A), x) ==> App("R", x))
+        val e2 = Forall(Seq(x of A, y of B), (App(ScopeSubtype.subtypePred(A), x) and App(ScopeSubtype.subtypePred(B), y)) ==> App("R", x))
+        val e3 = Exists(x of A, App(ScopeSubtype.subtypePred(A), x) and App("R", z))
+        val e4 = Exists(Seq(x of A, y of B), AndList(App(ScopeSubtype.subtypePred(A), x), App(ScopeSubtype.subtypePred(B), y), App("R", z)))
+
+        ScopeSubtype.addBoundsPredicates(t1) should be(e1)
+        ScopeSubtype.addBoundsPredicates(t2) should be(e2)
+        ScopeSubtype.addBoundsPredicates(t3) should be(e3)
+        ScopeSubtype.addBoundsPredicates(t4) should be(e4)
+    }
+}


### PR DESCRIPTION
1. Converting instance back for the predicates subset method, and added some unit tests.
2. Commented out ClosureElimination, integerSemantics in all compilers, and make sure EnumElimination is in all compilers

