### PR TITLE
Bug fix in non-distinct constants method returning instance

### DIFF
--- a/core/src/main/scala/fortress/compiler/FortressCompilers.scala
+++ b/core/src/main/scala/fortress/compiler/FortressCompilers.scala
@@ -210,6 +210,7 @@ class PredUpperBoundCompiler extends LogicCompiler {
         transformerSequence += TypecheckSanitizeTransformer
         transformerSequence += new ScopeSubtypeTransformer // Must be before skolemization
         transformerSequence += EnumEliminationTransformer
+        transformerSequence += SortInferenceTransformer
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
         transformerSequence ++= symmetryBreakingTransformers

--- a/core/src/main/scala/fortress/interpretation/EvaluationBasedInterpretation.scala
+++ b/core/src/main/scala/fortress/interpretation/EvaluationBasedInterpretation.scala
@@ -31,7 +31,7 @@ abstract class EvaluationBasedInterpretation(sig: Signature) extends Interpretat
     
     override val functionInterpretations: Map[fortress.msfol.FuncDecl, Map[Seq[Value], Value]] = {
         for(f <- sig.functionDeclarations) yield (f -> {
-            for(argList <- ArgumentListGenerator.generate(f, scopes))
+            for(argList <- ArgumentListGenerator.generate(f, scopes, Some(sortInterpretations)))
             yield (argList -> evaluateFunction(f, argList))
         }.toMap)
     }.toMap

--- a/core/src/main/scala/fortress/util/ArgumentListGenerator.scala
+++ b/core/src/main/scala/fortress/util/ArgumentListGenerator.scala
@@ -3,7 +3,7 @@ package fortress.util
 import fortress.msfol._
 import fortress.data._
 
-class ArgumentListGenerator(scopes: PartialFunction[Sort, Int]) {
+class ArgumentListGenerator(scopes: PartialFunction[Sort, Int], sortInterpretations: Option[Map[Sort, Seq[Value]]] = None) {
     
     /** Given a function f: A_1 x ... x A_n -> B, returns an iterable object containing
     all the possible argument combination to the functions. Each argument combination is given as
@@ -13,7 +13,13 @@ class ArgumentListGenerator(scopes: PartialFunction[Sort, Int]) {
         // and each A_i has generated domain D_i
         // get the list [D_1, ..., D_n]
         val seqOfDomainSeqs: IndexedSeq[IndexedSeq[Value]] = f.argSorts.toIndexedSeq.map (sort => sort match {
-            case SortConst(s) => DomainElement.range(1 to scopes(sort), sort)
+            case SortConst(s) => {
+                if(sortInterpretations.nonEmpty && sortInterpretations.get.contains(sort)){
+                    sortInterpretations.get(sort).toIndexedSeq
+                } else{
+                    DomainElement.range(1 to scopes(sort), sort)
+                }
+            }
             case BoolSort => Vector(Top, Bottom)
             case _ => ???
         })
@@ -27,7 +33,7 @@ class ArgumentListGenerator(scopes: PartialFunction[Sort, Int]) {
 }
 
 object ArgumentListGenerator {
-    def generate(f: FuncDecl, scopes: PartialFunction[Sort, Int]): Iterable[Seq[Value]] = {
-        (new ArgumentListGenerator(scopes)).allArgumentListsOfFunction(f)
+    def generate(f: FuncDecl, scopes: PartialFunction[Sort, Int], sortInterpretations: Option[Map[Sort, Seq[Value]]] = None): Iterable[Seq[Value]] = {
+        (new ArgumentListGenerator(scopes, sortInterpretations)).allArgumentListsOfFunction(f)
     }
 }

--- a/core/src/test/scala/interpretation/EvaluationBasedInterpretationTest.scala
+++ b/core/src/test/scala/interpretation/EvaluationBasedInterpretationTest.scala
@@ -7,48 +7,136 @@ class EvaluationBasedInterpretationTest extends UnitSuite {
     val A = Sort.mkSortConst("A")
     val c = Var("c")
     val f = FuncDecl("f", A, A)
-    
+
     val signature = Signature.empty
-        .withSort(A)
-        .withConstant(c of A)
-        .withFunctionDeclaration(f)
-    
+      .withSort(A)
+      .withConstant(c of A)
+      .withFunctionDeclaration(f)
+
     test("create interpretation") {
         object Interp extends EvaluationBasedInterpretation(signature) {
             def evaluateSort(s: Sort): Seq[Value] = s match {
                 case `A` => DomainElement.range(1 to 5, A)
                 case _ => fail("Unexpected sort: " + s.toString)
             }
-            
+
             def evaluateConstant(const: AnnotatedVar): Value = const match {
                 case AnnotatedVar(Var("c"), A) => DomainElement(3, A)
                 case _ => fail("Unexpected constant: " + c.toString)
             }
-            
+
             def evaluateFunction(func: FuncDecl, argList: Seq[Value]): Value = (func, argList) match {
-                case (`f`, Seq(DomainElement(1, A))) => DomainElement(2, A) 
-                case (`f`, Seq(DomainElement(2, A))) => DomainElement(3, A) 
-                case (`f`, Seq(DomainElement(3, A))) => DomainElement(4, A) 
-                case (`f`, Seq(DomainElement(4, A))) => DomainElement(5, A) 
-                case (`f`, Seq(DomainElement(5, A))) => DomainElement(1, A) 
+                case (`f`, Seq(DomainElement(1, A))) => DomainElement(2, A)
+                case (`f`, Seq(DomainElement(2, A))) => DomainElement(3, A)
+                case (`f`, Seq(DomainElement(3, A))) => DomainElement(4, A)
+                case (`f`, Seq(DomainElement(4, A))) => DomainElement(5, A)
+                case (`f`, Seq(DomainElement(5, A))) => DomainElement(1, A)
                 case _ => fail("Unexpected (func, argList) pair: " + (func, argList).toString)
-            } 
+            }
         }
-        
-        Interp.constantInterpretations should be (Map(
+
+        Interp.constantInterpretations should be(Map(
             (c of A) -> DomainElement(3, A)
         ))
-        
-        Interp.sortInterpretations should be (Map(
+
+        Interp.sortInterpretations should be(Map(
             A -> DomainElement.range(1 to 5, A)
         ))
-        
-        Interp.functionInterpretations should be (Map(f -> Map(
+
+        Interp.functionInterpretations should be(Map(f -> Map(
             Seq(DomainElement(1, A)) -> DomainElement(2, A),
             Seq(DomainElement(2, A)) -> DomainElement(3, A),
             Seq(DomainElement(3, A)) -> DomainElement(4, A),
             Seq(DomainElement(4, A)) -> DomainElement(5, A),
             Seq(DomainElement(5, A)) -> DomainElement(1, A)
+        )))
+    }
+
+    test("create interpretation with non-distinct constants") {
+        object Interp extends EvaluationBasedInterpretation(signature) {
+            def evaluateSort(s: Sort): Seq[Value] = s match {
+                case `A` => List(1, 3, 4) map (i => DomainElement(i, A))
+                case _ => fail("Unexpected sort: " + s.toString)
+            }
+
+            def evaluateConstant(const: AnnotatedVar): Value = const match {
+                case AnnotatedVar(Var("c"), A) => DomainElement(3, A)
+                case _ => fail("Unexpected constant: " + c.toString)
+            }
+
+            def evaluateFunction(func: FuncDecl, argList: Seq[Value]): Value = (func, argList) match {
+                case (`f`, Seq(DomainElement(1, A))) => DomainElement(3, A)
+                case (`f`, Seq(DomainElement(3, A))) => DomainElement(4, A)
+                case (`f`, Seq(DomainElement(4, A))) => DomainElement(1, A)
+                case _ => fail("Unexpected (func, argList) pair: " + (func, argList).toString)
+            }
+        }
+
+        Interp.constantInterpretations should be(Map(
+            (c of A) -> DomainElement(3, A)
+        ))
+
+        Interp.sortInterpretations should be(Map(
+            A -> (List(1, 3, 4) map (i => DomainElement(i, A)))
+        ))
+
+        Interp.functionInterpretations should be(Map(f -> Map(
+            Seq(DomainElement(1, A)) -> DomainElement(3, A),
+            Seq(DomainElement(3, A)) -> DomainElement(4, A),
+            Seq(DomainElement(4, A)) -> DomainElement(1, A),
+        )))
+    }
+
+
+    test("create interpretation with non-distinct constants, built in sorts") {
+        val t = FuncDecl("t", A, BoolSort, A)
+
+        val newSignature = signature.withFunctionDeclaration(t)
+
+        object Interp extends EvaluationBasedInterpretation(newSignature) {
+            def evaluateSort(s: Sort): Seq[Value] = s match {
+                case `A` => List(1, 3, 4) map (i => DomainElement(i, A))
+                case _ => fail("Unexpected sort: " + s.toString)
+            }
+
+            def evaluateConstant(const: AnnotatedVar): Value = const match {
+                case AnnotatedVar(Var("c"), A) => DomainElement(3, A)
+                case _ => fail("Unexpected constant: " + c.toString)
+            }
+
+            def evaluateFunction(func: FuncDecl, argList: Seq[Value]): Value = (func, argList) match {
+                case (`f`, Seq(DomainElement(1, A))) => DomainElement(3, A)
+                case (`f`, Seq(DomainElement(3, A))) => DomainElement(4, A)
+                case (`f`, Seq(DomainElement(4, A))) => DomainElement(1, A)
+                case (`t`, Seq(DomainElement(1, A), Top)) => DomainElement(3, A)
+                case (`t`, Seq(DomainElement(3, A), Top)) => DomainElement(4, A)
+                case (`t`, Seq(DomainElement(4, A), Top)) => DomainElement(1, A)
+                case (`t`, Seq(DomainElement(1, A), Bottom)) => DomainElement(4, A)
+                case (`t`, Seq(DomainElement(3, A), Bottom)) => DomainElement(1, A)
+                case (`t`, Seq(DomainElement(4, A), Bottom)) => DomainElement(3, A)
+                case _ => fail("Unexpected (func, argList) pair: " + (func, argList).toString)
+            }
+        }
+
+        Interp.constantInterpretations should be(Map(
+            (c of A) -> DomainElement(3, A)
+        ))
+
+        Interp.sortInterpretations should be(Map(
+            A -> (List(1, 3, 4) map (i => DomainElement(i, A)))
+        ))
+
+        Interp.functionInterpretations should be(Map(f -> Map(
+            Seq(DomainElement(1, A)) -> DomainElement(3, A),
+            Seq(DomainElement(3, A)) -> DomainElement(4, A),
+            Seq(DomainElement(4, A)) -> DomainElement(1, A),
+        ), t -> Map(
+            Seq(DomainElement(1, A), Top) -> DomainElement(3, A),
+            Seq(DomainElement(3, A), Top) -> DomainElement(4, A),
+            Seq(DomainElement(4, A), Top) -> DomainElement(1, A),
+            Seq(DomainElement(1, A), Bottom) -> DomainElement(4, A),
+            Seq(DomainElement(3, A), Bottom) -> DomainElement(1, A),
+            Seq(DomainElement(4, A), Bottom) -> DomainElement(3, A),
         )))
     }
 }


### PR DESCRIPTION
Before, when returning the instance it assumes domain elements are numbered from 1 to scope of that sort. However, with the non-distinct constants approach, it is possible that only some of them are valid. 
For example, consider the case only domain elements [1,3,4] are valid in the set of possible domain elements [1,2,3,4,5] if we have scope 5.