### PR TITLE
Optimize process smtlib evaluation by using get-model whenever possible

### DIFF
--- a/core/src/main/scala/fortress/interpretation/EvaluationBasedInterpretation.scala
+++ b/core/src/main/scala/fortress/interpretation/EvaluationBasedInterpretation.scala
@@ -11,7 +11,7 @@ import fortress.util.ArgumentListGenerator
 abstract class EvaluationBasedInterpretation(sig: Signature) extends Interpretation {
     protected def evaluateConstant(c: AnnotatedVar): Value
     protected def evaluateSort(s: Sort): Seq[Value]
-    protected def evaluateFunction(f: FuncDecl, argList: Seq[Value]): Value
+    protected def evaluateFunction(f: FuncDecl, scopes: Map[Sort, Int]): Map[Seq[Value], Value]
     
     private def scopes: Map[Sort, Int] = for((sort, seq) <- sortInterpretations) yield (sort -> seq.size)
     
@@ -30,9 +30,6 @@ abstract class EvaluationBasedInterpretation(sig: Signature) extends Interpretat
     }.toMap
     
     override val functionInterpretations: Map[fortress.msfol.FuncDecl, Map[Seq[Value], Value]] = {
-        for(f <- sig.functionDeclarations) yield (f -> {
-            for(argList <- ArgumentListGenerator.generate(f, scopes, Some(sortInterpretations)))
-            yield (argList -> evaluateFunction(f, argList))
-        }.toMap)
+            for(f <- sig.functionDeclarations) yield (f -> evaluateFunction(f, scopes))
     }.toMap
 }

--- a/core/src/main/scala/fortress/solverinterface/ProcessBuilderSolver.scala
+++ b/core/src/main/scala/fortress/solverinterface/ProcessBuilderSolver.scala
@@ -27,7 +27,10 @@ trait ProcessBuilderSolver extends SolverSession {
 
 object ProcessBuilderSolver {
     val smt2Model: Regex = """^\(\((\S+|\(.+\)) (\S+|\(.+\))\)\)$""".r
+    val bitVecType: Regex = """\(_ BitVec (\d+)\)""".r
     val bitVecLiteral: Regex = """^#(.)(.+)$""".r
     val bitVecExpr: Regex = """\(_ bv(\d+) (\d+)\)""".r
+    val bitVecExprCondensed: Regex = """(\d+)aaBitVecExpraa(\d+)""".r
     val negativeInteger: Regex = """\(- (\d+)\)""".r
+    val negativeIntegerCondensed: Regex = """aaNegativeIntaa(\d+)""".r
 }

--- a/core/src/main/scala/fortress/solverinterface/ProcessSmtlibEvaluation.scala
+++ b/core/src/main/scala/fortress/solverinterface/ProcessSmtlibEvaluation.scala
@@ -26,7 +26,36 @@ trait ProcessSmtlibEvaluation extends ProcessBuilderSolver {
                 domainElement <- DomainElement.interpretName(name)
             } yield (value -> domainElement)
         ).toMap
-        
+
+        // Get model and store it in a map from identifier to string tokens
+        val smtInterpTokens: Map[String, Array[String]] = {
+            processSession.get.write("(get-model)\n")
+            processSession.get.flush()
+
+            var line: String = null
+            val smtInterpTokens = scala.collection.mutable.Map[String, Array[String]]()
+            var currentFunc: String = null
+            while ({line = processSession.get.readLine(); line != ")"}) {
+                // Replace expressions that has space in them, such as bit vector type, bit vector
+                // expression and negative integer with their condensed form (remove spaces)
+                line = line.replaceAll(ProcessBuilderSolver.bitVecType.regex, """BitVec$1""")
+                line = line.replaceAll(ProcessBuilderSolver.bitVecExpr.regex, """$1aaBitVecExpraa$2""")
+                line = line.replaceAll(ProcessBuilderSolver.negativeInteger.regex, """aaNegativeIntaa$1""")
+                // Remove brackets and "and", split into tokens
+                line = line.replaceAll("[()]", "")
+                val tokens = line.split(" +").filterNot(_ == "").filterNot(_ == "and")
+                // Store them in a map that maps each function name to a list of tokens
+                if (tokens.length > 1 && tokens(0).equals("define-fun")) {
+                    currentFunc = NameConverter.nameWithoutAffix(tokens(1))
+                    smtInterpTokens(currentFunc) = Array[String]()
+                }
+                if (currentFunc != null) {
+                    smtInterpTokens(currentFunc) ++= tokens
+                }
+            }
+            smtInterpTokens.toMap
+        }
+
         object Solution extends EvaluationBasedInterpretation(theory.get.signature) {
             override protected def evaluateConstant(c: AnnotatedVar): Value = {
                 smtValueToFortressValue(
@@ -35,8 +64,8 @@ trait ProcessSmtlibEvaluation extends ProcessBuilderSolver {
                     smtValueToDomainElement
                 )
             }
-            
-            override protected def evaluateFunction(f: FuncDecl, argList: Seq[Value]): Value = {
+
+            protected def evaluateFunctionByGetValue(f: FuncDecl, argList: Seq[Value]): Value = {
                 processSession.get.write("(get-value ((")
                 processSession.get.write(NameConverter.nameWithAffix(f.name))
                 for(arg <- argList){
@@ -57,7 +86,79 @@ trait ProcessSmtlibEvaluation extends ProcessBuilderSolver {
                 }
                 smtValueToFortressValue(value, f.resultSort, smtValueToDomainElement)
             }
-            
+
+            override protected def evaluateFunction(f: FuncDecl, scopes: Map[Sort, Int]): Map[Seq[Value], Value] = {
+                try {
+                    // Get identifiers of all function parameters
+                    val paramIdentifiers = for (i <- f.argSorts.indices) yield {
+                        smtInterpTokens(f.name)(2 + i * 2)
+                    }
+
+                    // Set default value based on return sort
+                    var defaultValue: Value = Bottom
+                    f.resultSort match {
+                        case BoolSort =>
+                            if (smtInterpTokens(f.name).last.equals("true")) {
+                                defaultValue = Top
+                            }
+                        case _ => defaultValue = smtValueToFortressValue(smtInterpTokens(f.name).last, f.resultSort, smtValueToDomainElement)
+                    }
+                    val interpMap: scala.collection.mutable.Map[Seq[Value], Value] = collection.mutable.Map({
+                        for (argList <- ArgumentListGenerator.generate(f, scopes, Some(sortInterpretations)))
+                            yield (argList -> defaultValue)
+                    }.toMap.toSeq: _*)
+
+                    // Parse the output based on either ite or plain boolean format
+                    var index = smtInterpTokens(f.name).indexOf("ite")
+                    if (smtInterpTokens(f.name).indexOf("ite") > -1) {
+                        index = index - 1
+                        while (index + 1 + f.argSorts.size * 3 < smtInterpTokens(f.name).length) {
+                            // Using "ite" as an anchor
+                            index = index + 1
+                            // Get arguments
+                            val argList = for (i <- f.argSorts.indices)
+                                yield {
+                                    index = index + 3
+                                    // Handle the case of "(= value identifier)"
+                                    var possibleParam = smtInterpTokens(f.name)(index)
+                                    if (possibleParam.equals(paramIdentifiers(i))) possibleParam = smtInterpTokens(f.name)(index - 1)
+                                    smtValueToFortressValue(possibleParam, f.argSorts(i), smtValueToDomainElement)
+                                }
+                            index = index + 1
+                            // Get value and update interpretation map
+                            interpMap.update(argList, smtValueToFortressValue(smtInterpTokens(f.name)(index), f.resultSort, smtValueToDomainElement))
+                        }
+                    } else if (smtInterpTokens(f.name).indexOf("=") > -1) {
+                        // Using "ite" as an anchor
+                        index = smtInterpTokens(f.name).indexOf("=") - 1
+                        while (index + f.argSorts.size * 3 < smtInterpTokens(f.name).length) {
+                            // Get arguments
+                            val argList = for (x <- f.argSorts)
+                                yield {
+                                    index = index + 3
+                                    smtValueToFortressValue(smtInterpTokens(f.name)(index), x, smtValueToDomainElement)
+                                }
+                            // Get value and update interpretation map
+                            interpMap.update(argList, Top)
+                        }
+                    } else {
+                        // Notice it is not necessarily in impossible state to get here, it
+                        // is possible that default value has been correctly set. But we want
+                        // to raise exception to be safe. It also handles other responses like
+                        // "x!0" and "(and x!0 x!1)".
+                        Errors.Internal.impossibleState
+                    }
+                    interpMap.toMap
+                } catch {
+                    case _: Throwable =>
+                        // Fall back to the (get-value) approach
+                        {
+                            for (argList <- ArgumentListGenerator.generate(f, scopes, Some(sortInterpretations)))
+                                yield argList -> evaluateFunctionByGetValue(f, argList)
+                        }.toMap
+                }
+            }
+
             override protected def evaluateSort(sort: Sort): Seq[Value] = {
                 smtValueToDomainElement.values.filter(
                     domainElement => domainElement.sort == sort
@@ -103,6 +204,7 @@ trait ProcessSmtlibEvaluation extends ProcessBuilderSolver {
             }
             case IntSort => value match {
                 case ProcessBuilderSolver.negativeInteger(digits) => IntegerLiteral(-(digits.toInt))
+                case ProcessBuilderSolver.negativeIntegerCondensed(digits) => IntegerLiteral(-(digits.toInt))
                 case _ => IntegerLiteral(value.toInt)
             }
             case BitVectorSort(bitwidth) => value match {
@@ -112,6 +214,10 @@ trait ProcessSmtlibEvaluation extends ProcessBuilderSolver {
                     case _ => Errors.Internal.impossibleState
                 }
                 case ProcessBuilderSolver.bitVecExpr(digits, bitw) => {
+                    Errors.Internal.assertion(bitw.toInt == bitwidth)
+                    BitVectorLiteral(digits.toInt, bitwidth)
+                }
+                case ProcessBuilderSolver.bitVecExprCondensed(digits, bitw) => {
                     Errors.Internal.assertion(bitw.toInt == bitwidth)
                     BitVectorLiteral(digits.toInt, bitwidth)
                 }

--- a/core/src/test/scala/interpretation/EvaluationBasedInterpretationTest.scala
+++ b/core/src/test/scala/interpretation/EvaluationBasedInterpretationTest.scala
@@ -25,13 +25,15 @@ class EvaluationBasedInterpretationTest extends UnitSuite {
                 case _ => fail("Unexpected constant: " + c.toString)
             }
 
-            def evaluateFunction(func: FuncDecl, argList: Seq[Value]): Value = (func, argList) match {
-                case (`f`, Seq(DomainElement(1, A))) => DomainElement(2, A)
-                case (`f`, Seq(DomainElement(2, A))) => DomainElement(3, A)
-                case (`f`, Seq(DomainElement(3, A))) => DomainElement(4, A)
-                case (`f`, Seq(DomainElement(4, A))) => DomainElement(5, A)
-                case (`f`, Seq(DomainElement(5, A))) => DomainElement(1, A)
-                case _ => fail("Unexpected (func, argList) pair: " + (func, argList).toString)
+            def evaluateFunction(f: FuncDecl, scopes: Map[Sort, Int]): Map[Seq[Value], Value] = (f, scopes) match {
+                case (`f`, scopes) => Map(
+                    Seq(DomainElement(1, A)) -> DomainElement(2, A),
+                    Seq(DomainElement(2, A)) -> DomainElement(3, A),
+                    Seq(DomainElement(3, A)) -> DomainElement(4, A),
+                    Seq(DomainElement(4, A)) -> DomainElement(5, A),
+                    Seq(DomainElement(5, A)) -> DomainElement(1, A)
+                )
+                case _ => fail("Unexpected (f, scopes) pair: " + (f, scopes).toString)
             }
         }
 
@@ -64,11 +66,13 @@ class EvaluationBasedInterpretationTest extends UnitSuite {
                 case _ => fail("Unexpected constant: " + c.toString)
             }
 
-            def evaluateFunction(func: FuncDecl, argList: Seq[Value]): Value = (func, argList) match {
-                case (`f`, Seq(DomainElement(1, A))) => DomainElement(3, A)
-                case (`f`, Seq(DomainElement(3, A))) => DomainElement(4, A)
-                case (`f`, Seq(DomainElement(4, A))) => DomainElement(1, A)
-                case _ => fail("Unexpected (func, argList) pair: " + (func, argList).toString)
+            def evaluateFunction(f: FuncDecl, scopes: Map[Sort, Int]): Map[Seq[Value], Value] = (f, scopes) match {
+                case (`f`, scopes) => Map(
+                        Seq(DomainElement(1, A)) -> DomainElement(3, A),
+                        Seq(DomainElement(3, A)) -> DomainElement(4, A),
+                        Seq(DomainElement(4, A)) -> DomainElement(1, A)
+                )
+                case _ => fail("Unexpected (f, scopes) pair: " + (f, scopes).toString)
             }
         }
 
@@ -104,17 +108,21 @@ class EvaluationBasedInterpretationTest extends UnitSuite {
                 case _ => fail("Unexpected constant: " + c.toString)
             }
 
-            def evaluateFunction(func: FuncDecl, argList: Seq[Value]): Value = (func, argList) match {
-                case (`f`, Seq(DomainElement(1, A))) => DomainElement(3, A)
-                case (`f`, Seq(DomainElement(3, A))) => DomainElement(4, A)
-                case (`f`, Seq(DomainElement(4, A))) => DomainElement(1, A)
-                case (`t`, Seq(DomainElement(1, A), Top)) => DomainElement(3, A)
-                case (`t`, Seq(DomainElement(3, A), Top)) => DomainElement(4, A)
-                case (`t`, Seq(DomainElement(4, A), Top)) => DomainElement(1, A)
-                case (`t`, Seq(DomainElement(1, A), Bottom)) => DomainElement(4, A)
-                case (`t`, Seq(DomainElement(3, A), Bottom)) => DomainElement(1, A)
-                case (`t`, Seq(DomainElement(4, A), Bottom)) => DomainElement(3, A)
-                case _ => fail("Unexpected (func, argList) pair: " + (func, argList).toString)
+            def evaluateFunction(func: FuncDecl, scopes: Map[Sort, Int]): Map[Seq[Value], Value] = (func, scopes) match {
+                case (`f`, scopes) => Map(
+                    Seq(DomainElement(1, A)) -> DomainElement(3, A),
+                    Seq(DomainElement(3, A)) -> DomainElement(4, A),
+                    Seq(DomainElement(4, A)) -> DomainElement(1, A)
+                )
+                case (`t`, scopes) => Map(
+                    Seq(DomainElement(1, A), Top) -> DomainElement(3, A),
+                    Seq(DomainElement(3, A), Top) -> DomainElement(4, A),
+                    Seq(DomainElement(4, A), Top) -> DomainElement(1, A),
+                    Seq(DomainElement(1, A), Bottom) -> DomainElement(4, A),
+                    Seq(DomainElement(3, A), Bottom) -> DomainElement(1, A),
+                    Seq(DomainElement(4, A), Bottom) -> DomainElement(3, A)
+                )
+                case _ => fail("Unexpected (f, scopes) pair: " + (f, scopes).toString)
             }
         }
 


### PR DESCRIPTION
Optimize process smtlib evaluation by using (get-model) whenever possible

Problem: We noticed that in some cases, getting function interpretation by querying Z3 process back and forth through (get-value) can take really long time.  So we now use (get-model) whenever possible to reduce I/O time.