### PR TITLE
Add datatype transformer and change smtlib conversion accordingly

### DIFF
--- a/core/src/main/scala/fortress/compiler/CompilerResult.scala
+++ b/core/src/main/scala/fortress/compiler/CompilerResult.scala
@@ -1,8 +1,7 @@
 package fortress.compiler
 
-import fortress.msfol.Theory
+import fortress.msfol.{Declaration, Theory}
 import fortress.interpretation.Interpretation
-import fortress.msfol.Declaration
 
 /** Result from a compiler. */
 trait CompilerResult {

--- a/core/src/main/scala/fortress/compiler/FortressCompilers.scala
+++ b/core/src/main/scala/fortress/compiler/FortressCompilers.scala
@@ -36,6 +36,32 @@ abstract class BaseFortressCompiler(integerSemantics: IntegerSemantics) extends 
     def symmetryBreakingTransformers: Seq[ProblemStateTransformer]
 }
 
+abstract class BaseFortressCompilerEnums(integerSemantics: IntegerSemantics) extends LogicCompiler {
+    override def transformerSequence: Seq[ProblemStateTransformer] = {
+        val transformerSequence = new scala.collection.mutable.ListBuffer[ProblemStateTransformer]
+        transformerSequence += TypecheckSanitizeTransformer
+        transformerSequence += EnumEliminationTransformer
+        //        integerSemantics match {
+        //            case Unbounded => ()
+        //            case ModularSigned(bitwidth) => {
+        //                transformerSequence += new IntegerFinitizationTransformer(bitwidth)
+        //            }
+        //        }
+        //        transformerSequence += ClosureEliminationTransformer
+        transformerSequence += NnfTransformer
+        transformerSequence += SkolemizeTransformer
+        transformerSequence ++= symmetryBreakingTransformers
+        transformerSequence += StandardQuantifierExpansionTransformer
+        transformerSequence += StandardRangeFormulaTransformer
+        transformerSequence += new SimplifyTransformer
+        transformerSequence += DatatypeTransformer
+        transformerSequence.toList
+    }
+
+    def symmetryBreakingTransformers: Seq[ProblemStateTransformer]
+}
+
+
 class FortressZEROCompiler(integerSemantics: IntegerSemantics) extends BaseFortressCompiler(integerSemantics) {
     override def symmetryBreakingTransformers: Seq[ProblemStateTransformer] = Seq.empty
 }

--- a/core/src/main/scala/fortress/interpretation/EvaluationBasedInterpretation.scala
+++ b/core/src/main/scala/fortress/interpretation/EvaluationBasedInterpretation.scala
@@ -27,7 +27,7 @@ abstract class EvaluationBasedInterpretation(sig: Signature) extends Interpretat
     
     override val sortInterpretations: Map[Sort, Seq[Value]] = {
         for(sort <- sig.sorts) yield (sort -> evaluateSort(sort))
-    }.toMap
+    }.toMap ++ sig.enumConstants
     
     override val functionInterpretations: Map[fortress.msfol.FuncDecl, Map[Seq[Value], Value]] = {
             for(f <- sig.functionDeclarations) yield (f -> evaluateFunction(f, scopes))

--- a/core/src/main/scala/fortress/modelfind/CompilationModelFinder.scala
+++ b/core/src/main/scala/fortress/modelfind/CompilationModelFinder.scala
@@ -88,7 +88,7 @@ with ModelFinderSettings {
         val instance = solverSession.get.solution
             .withoutDeclarations(compilerResult.get.skipForNextInterpretation)
             
-        val newAxiom = Not(And.smart(instance.toConstraints.toList map (_.eliminateDomainElements)))
+        val newAxiom = Not(And.smart(instance.toConstraints.toList map (_.eliminateDomainElementsConstants)))
         
         solverSession.get.addAxiom(newAxiom)
         solverSession.get.solve(timeoutMilliseconds)

--- a/core/src/main/scala/fortress/operations/TermOps.scala
+++ b/core/src/main/scala/fortress/operations/TermOps.scala
@@ -65,7 +65,9 @@ case class TermOps private (term: Term) {
 
     def simplifyWithLearnedLiterals(learnedLiterals: Map[Term, LeafTerm]): Term = SimplifierWithLearnedLiterals.simplify(term, learnedLiterals)
 
-    def eliminateDomainElements: Term = DomainElementEliminator(term)
+    def eliminateDomainElementsConstants: Term = DomainElementEliminatorConstants(term)
+
+    def eliminateDomainElementsEnums: Term = DomainElementEliminatorEnums(term)
     
     def eliminateEnumValues(eliminationMapping: Map[EnumValue, DomainElement]): Term = EnumValueEliminator(eliminationMapping)(term)
     

--- a/core/src/main/scala/fortress/transformers/DatatypeTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/DatatypeTransformer.scala
@@ -1,0 +1,38 @@
+package fortress.transformers
+
+import fortress.msfol._
+import fortress.operations.TermOps._
+import fortress.operations.TheoryOps._
+
+/** Introduces enum values to simulate the domain elements, replacing occurrences
+  * of domain elements with the appropriate constant. Leaves other aspects of the
+  * Problem unchanged.
+  */
+object DatatypeTransformer extends ProblemStateTransformer {
+
+    override def apply(problemState: ProblemState): ProblemState = problemState match {
+        case ProblemState(theory, scopes, skc, skf, rangeRestricts, unapplyInterp) => {
+            val enumValuesMap: Map[Sort, Seq[EnumValue]] =
+                (for (sort <- theory.sorts if !sort.isBuiltin && scopes.contains(sort)) yield {
+                    val enumValues = DomainElement.range(1 to scopes(sort), sort).map(_.asEnumValue)
+                    (sort, enumValues)
+                }).toMap
+
+            // Convert domain elements in existing axioms to enum values
+            val convertedAxioms = theory.axioms map (_.eliminateDomainElementsEnums)
+
+            var newTheory = theory.withoutAxioms
+              .withAxioms(convertedAxioms)
+
+            newTheory = enumValuesMap.foldLeft(newTheory) {
+                case (t, (s, enumValueSeq)) => {
+                    t.withEnumSort(s, enumValueSeq: _*)
+                }
+            }
+
+            ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapplyInterp)
+        }
+    }
+
+    override def name: String = "Domain Elimination To Enums Transformer"
+}

--- a/core/src/main/scala/fortress/transformers/DomainEliminationTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/DomainEliminationTransformer.scala
@@ -31,7 +31,7 @@ object DomainEliminationTransformer extends ProblemStateTransformer {
             ) yield Distinct(domainElems map (_.asSmtConstant))
             
             // Eliminate domain elements in existing axioms
-            val convertedAxioms = theory.axioms map (_.eliminateDomainElements)
+            val convertedAxioms = theory.axioms map (_.eliminateDomainElementsConstants)
             
             val newTheory = theory.withoutAxioms
                 .withConstants(domainConstants)
@@ -42,5 +42,5 @@ object DomainEliminationTransformer extends ProblemStateTransformer {
         }
     }
     
-    override def name: String = "Domain Elimination Transformer"
+    override def name: String = "Domain Elimination To Constants Transformer"
 }

--- a/core/src/main/scala/fortress/transformers/DomainEliminationTransformer2.scala
+++ b/core/src/main/scala/fortress/transformers/DomainEliminationTransformer2.scala
@@ -31,7 +31,7 @@ class DomainEliminationTransformer2 extends ProblemStateTransformer {
             // ) yield Distinct(domainElems map (_.asSmtConstant))
             
             // Eliminate domain elements in existing axioms
-            val convertedAxioms = theory.axioms map (_.eliminateDomainElements)
+            val convertedAxioms = theory.axioms map (_.eliminateDomainElementsConstants)
             
             val newTheory = theory.withoutAxioms
                 .withConstants(domainConstants)
@@ -42,5 +42,5 @@ class DomainEliminationTransformer2 extends ProblemStateTransformer {
         }
     }
     
-    override def name: String = "Domain Elimination Transformer 2"
+    override def name: String = "Domain Elimination To Constants Transformer 2"
 }

--- a/core/src/test/scala/operations/SmtlibConversionTests.scala
+++ b/core/src/test/scala/operations/SmtlibConversionTests.scala
@@ -16,6 +16,8 @@ class SmtlibConversionTests extends UnitSuite {
     val P = FuncDecl.mkFuncDecl("P", A, B, Sort.Bool)
     val q = Var("q")
     val r = Var("r")
+    val _1A = DomainElement(1, A).asEnumValue
+    val _2A = DomainElement(2, A).asEnumValue
     
     test("basic conversion") {
         val formula1 = Forall(Seq(x of A, y of B), App("f", x) === y)
@@ -53,10 +55,11 @@ class SmtlibConversionTests extends UnitSuite {
                     .withSorts(A, B)
                     .withFunctionDeclarations(f, P)
                     .withConstants(x of A, y of B)
+                    .withEnumSort(A, _1A, _2A)
                     .withAxiom(App("P", Seq(x,y)))
 
-        theory.smtlib should be ("(declare-sort A 0)" +
-                                "(declare-sort B 0)" +
+        theory.smtlib should be ("(declare-sort B 0)" +
+                                "(declare-datatypes () ((A _@1Aaa _@2Aaa)))" +
                                 "(declare-fun faa (A) B)" +
                                 "(declare-fun Paa (A B) Bool)" +
                                 "(declare-const xaa A)" +
@@ -103,5 +106,13 @@ class SmtlibConversionTests extends UnitSuite {
         
         converter.writeSortDecl(A)
         writer.toString should be ("(declare-sort A 0)")
+    }
+
+    test("enum constants declarations") {
+        val writer = new java.io.StringWriter
+        val converter = new SmtlibConverter(writer)
+
+        converter.writeEnumConst(A, Seq(_1A, _2A))
+        writer.toString should be ("(declare-datatypes () ((A _@1Aaa _@2Aaa)))")
     }
 }

--- a/core/src/test/scala/transformers/DatatypeTransformerTests.scala
+++ b/core/src/test/scala/transformers/DatatypeTransformerTests.scala
@@ -1,0 +1,67 @@
+import org.scalatest._
+
+import fortress.msfol._
+import fortress.transformers._
+
+class DatatypeTransformerTests extends UnitSuite {
+    val A = Sort.mkSortConst("A")
+    val B = Sort.mkSortConst("B")
+    
+    val c = Var("c")
+    val d = Var("d")
+    val x = Var("x")
+    
+    test("standard domain elimination") {
+        val theory = Theory.empty
+            .withSorts(A, B)
+            .withConstants(c of A, d of B)
+            .withFunctionDeclaration(FuncDecl("f", A, A, B))
+            .withAxiom(App("f", c, DomainElement(1, A)) === DomainElement(3, B))
+            .withAxiom(Not(d === DomainElement(4, B)) ==> Exists(x of A, x === DomainElement(2, A)))
+        
+        val scopes = Map(A -> 2, B -> 4)
+
+        val _1A = DomainElement(1, A).asEnumValue
+        val _2A = DomainElement(2, A).asEnumValue
+        val _1B = DomainElement(1, B).asEnumValue
+        val _2B = DomainElement(2, B).asEnumValue
+        val _3B = DomainElement(3, B).asEnumValue
+        val _4B = DomainElement(4, B).asEnumValue
+        
+        val expectedTheory = Theory.empty
+            .withSorts(A, B)
+            .withConstants(c of A, d of B)
+            .withFunctionDeclaration(FuncDecl("f", A, A, B))
+            .withEnumSort(A, _1A, _2A)
+            .withEnumSort(B, _1B, _2B, _3B, _4B)
+            .withAxiom(App("f", c, _1A) === _3B)
+            .withAxiom(Not(d === _4B) ==> Exists(x of A, x === _2A))
+        
+        val transformer = DatatypeTransformer
+        transformer(ProblemState(theory, scopes)) should be (ProblemState(expectedTheory, scopes))
+    }
+    
+    test("scope of one") {
+        val theory = Theory.empty
+            .withSorts(A, B)
+            .withConstants(c of A, d of B)
+            .withAxiom(c === DomainElement(1, A))
+            .withAxiom(d === DomainElement(1, B))
+        
+        val scopes = Map(A -> 1, B -> 1)
+        
+        val _1A = DomainElement(1, A).asEnumValue
+        val _1B = DomainElement(1, B).asEnumValue
+        
+        val expectedTheory = Theory.empty
+            .withSorts(A, B)
+            .withConstants(c of A, d of B)
+            .withEnumSort(A, _1A)
+            .withEnumSort(B, _1B)
+            .withAxiom(c === _1A)
+            .withAxiom(d === _1B)
+        
+        val transformer = DatatypeTransformer
+        transformer(ProblemState(theory, scopes)) should be (ProblemState(expectedTheory, scopes))
+    }
+}


### PR DESCRIPTION
Add datatype transformer which convert domain elements to enum values. This newly added transformer can be used as a replacement of the DomainElementEliminationTransformer.

Modify smtlib conversion to convert enum values as datatypes.