### PR TITLE
Sort interpretation bug fix

### DIFF
--- a/core/src/main/scala/fortress/interpretation/EvaluationBasedInterpretation.scala
+++ b/core/src/main/scala/fortress/interpretation/EvaluationBasedInterpretation.scala
@@ -24,10 +24,10 @@ abstract class EvaluationBasedInterpretation(sig: Signature) extends Interpretat
             if DomainElement.interpretName(c.name).isEmpty // Exclude domain constants
 		} yield (c -> evaluateConstant(c))
     }.toMap
-    
+
     override val sortInterpretations: Map[Sort, Seq[Value]] = {
-        for(sort <- sig.sorts) yield (sort -> evaluateSort(sort))
-    }.toMap ++ sig.enumConstants
+        for (sort <- sig.sorts) yield sort -> evaluateSort(sort)
+    }.toMap ++ (sig.enumConstants transform ((_, v) => v.map(x => DomainElement.interpretName(x.name).get)))
     
     override val functionInterpretations: Map[fortress.msfol.FuncDecl, Map[Seq[Value], Value]] = {
             for(f <- sig.functionDeclarations) yield (f -> evaluateFunction(f, scopes))


### PR DESCRIPTION
Although sortInterpretations is typed as Map[Sort, Seq[Value]], but in fact it requires a map from sort to Domain Elements.
Here, we typecast enum values to domain elements. 