### PR TITLE
Bitvector/concat

### DIFF
--- a/core/src/main/scala/fortress/msfol/BuiltinFunctions.scala
+++ b/core/src/main/scala/fortress/msfol/BuiltinFunctions.scala
@@ -81,6 +81,14 @@ sealed trait BinaryBitVectorRelation extends BuiltinFunction {
     }
 }
 
+/** A function BV(n) x BV(m) -> BV(n + m) */
+sealed trait BitVectorConcatFunction extends BuiltinFunction {
+    override def resultSortFromArgSorts(sorts: Seq[Sort]): Option[Sort] = sorts match {
+        case Seq(BitVectorSort(n), BitVectorSort(m)) => Some(BitVectorSort(n + m))
+        case _ => None
+    }
+}
+
 case object BvPlus extends BinaryBitVectorFunction
 case object BvSub extends BinaryBitVectorFunction
 case object BvMult extends BinaryBitVectorFunction
@@ -95,3 +103,6 @@ case object BvSignedLE extends BinaryBitVectorRelation
 case object BvSignedLT extends BinaryBitVectorRelation
 case object BvSignedGE extends BinaryBitVectorRelation
 case object BvSignedGT extends BinaryBitVectorRelation
+
+
+case object BvConcat extends BitVectorConcatFunction

--- a/core/src/main/scala/fortress/msfol/Term.scala
+++ b/core/src/main/scala/fortress/msfol/Term.scala
@@ -233,7 +233,7 @@ case class BuiltinApp private (function: BuiltinFunction, arguments: Seq[Term]) 
 }
 
 object BuiltinApp {
-    def apply(function: BuiltinFunction, args: Term*): Term = BuiltinApp(function, args.toList)
+    def apply(function: BuiltinFunction, args: Term*): Term = BuiltinApp(function, args)
 }
 
 sealed trait Quantifier extends Term {

--- a/core/src/main/scala/fortress/operations/SmtlibConversion.scala
+++ b/core/src/main/scala/fortress/operations/SmtlibConversion.scala
@@ -103,6 +103,7 @@ class SmtlibConverter(writer: java.io.Writer) {
             case BuiltinApp(BvSignedLT, args) => writeGeneralApp("bvslt", args)
             case BuiltinApp(BvSignedGE, args) => writeGeneralApp("bvsge", args)
             case BuiltinApp(BvSignedGT, args) => writeGeneralApp("bvsgt", args)
+            case BuiltinApp(BvConcat, args) => writeGeneralApp("concat", args)
 
             case Closure(_, _, _, _) => Errors.Internal.impossibleState("Cannot convert Closure to smtlib")
             case ReflexiveClosure(_, _, _, _) =>  Errors.Internal.impossibleState("Cannot convert Reflexive Closure to smtlib")

--- a/core/src/test/scala/operations/SmtlibConversionTests.scala
+++ b/core/src/test/scala/operations/SmtlibConversionTests.scala
@@ -115,4 +115,9 @@ class SmtlibConversionTests extends UnitSuite {
         converter.writeEnumConst(A, Seq(_1A, _2A))
         writer.toString should be ("(declare-datatypes () ((A _@1Aaa _@2Aaa)))")
     }
+
+    test ("bitvector concat") {
+        val formula = BuiltinApp(BvConcat, BitVectorLiteral(0, 4), x)
+        formula.smtlib should be ("(concat (_ bv0 4) xaa)")
+    }
 }


### PR DESCRIPTION
Minor addition of a the concat function for bitvectors where (concat a b) is all of the bits of a and then all of the bits of b.