### PR TITLE
Bitvector Scope changes

### DIFF
--- a/core/src/main/scala/fortress/msfol/Sort.scala
+++ b/core/src/main/scala/fortress/msfol/Sort.scala
@@ -63,7 +63,7 @@ object Sort {
     val Bool: Sort = BoolSort
     val Int: Sort = IntSort
     val BoundedInt: Sort = BoundedIntSort
-    val unBoundedInt: Sort = UnBoundedIntSort
+    val UnBoundedInt: Sort = UnBoundedIntSort
 
     def BitVector(bitwidth: Int): Sort = BitVectorSort(bitwidth)
     

--- a/core/src/main/scala/fortress/problemstate/ProblemState.scala
+++ b/core/src/main/scala/fortress/problemstate/ProblemState.scala
@@ -26,9 +26,16 @@ case class ProblemState private(
 ) {
 //    Errors.Internal.precondition(scopes.values.forall(_. > 0), "Scopes must be positive")
     // allow setting scope for IntSort but not other builtins
-    Errors.Internal.precondition(scopes.keySet.forall( (x:Sort) => !x.isBuiltin || x == IntSort))
+    // Errors.Internal.precondition(scopes.keySet.forall( (x:Sort) => !x.isBuiltin || x == IntSort))
     // All scoped sorts are within the theory or IntSort
-    Errors.Internal.precondition(scopes.keySet subsetOf theory.sorts + IntSort)
+    // Errors.Internal.precondition(scopes.keySet subsetOf theory.sorts + IntSort)
+
+    // All bitvectors are properly sized
+    Errors.Internal.precondition(scopes.keySet.forall( (x:Sort) => x match {
+        case BitVectorSort(bitwidth) => scopes(x).size == math.pow(2, bitwidth).toInt
+        case _ => true
+    }),
+    "Bitvector has incorrect size")
     
     // TODO add precondition that theory domain elements respect the scopes
 
@@ -68,7 +75,7 @@ object ProblemState {
         }.toMap
 
         // Check there is no conflict between the enum scopes and the provided scopes
-        Errors.Internal.precondition(fortress.util.Maps.noConflict(enumScopes, scopes))
+        Errors.Internal.precondition(fortress.util.Maps.noConflict(enumScopes, scopes), "Conflict between enums and provide scopes")
 
         new ProblemState(
             theory,

--- a/core/src/main/scala/fortress/transformers/IntegerToBitVectorTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/IntegerToBitVectorTransformer.scala
@@ -13,6 +13,7 @@ import fortress.problemstate.Scope
 object IntegerToBitVectorTransformer extends ProblemStateTransformer {
     
     override def apply(problemState: ProblemState): ProblemState = {
+        var newProblemState = problemState
         if (problemState.scopes.contains(IntSort)) {
             val numValues = problemState.scopes(IntSort).size
             // Do log_2 of numValues to find bitwidth
@@ -28,12 +29,29 @@ object IntegerToBitVectorTransformer extends ProblemStateTransformer {
             // remove IntSort from the scopes map
             val newScopes: Map[Sort, Scope] = problemState.scopes.filter(x => !(x._1 == IntSort)) + (BitVectorSort(bitwidth) -> ExactScope(totalValues))
             // this is the return value
-            problemState.withTheory(Theory.mkTheoryWithSignature(newSig).withAxioms(newAxioms)).withScopes(newScopes)
-
-        } else {
-            // Nothing to change: return what was passed in
-            problemState
+            newProblemState = problemState.withTheory(Theory.mkTheoryWithSignature(newSig).withAxioms(newAxioms)).withScopes(newScopes)
         }
+
+        if (problemState.scopes.contains(BoundedIntSort)) {
+            val numValues = problemState.scopes(BoundedIntSort).size
+            // Do log_2 of numValues to find bitwidth
+            val bitwidth: Int = math.round(math.ceil(math.log(numValues) / math.log(2))).toInt
+            // We may store more values than initially given
+            val totalValues = math.pow(2, bitwidth).toInt
+
+            val newAxioms = problemState.theory.axioms.map( axiom => {
+                if( !axiom.isLia ) axiom.intToBitVector(bitwidth)
+                else axiom
+            })
+            val newSig = problemState.theory.signature.replaceIntegersWithBitVectors(bitwidth)
+            // remove IntSort from the scopes map
+            val newScopes: Map[Sort, Scope] = problemState.scopes.filter(x => !(x._1 == BoundedIntSort)) + (BitVectorSort(bitwidth) -> ExactScope(totalValues))
+            // this is the return value
+            newProblemState = problemState.withTheory(Theory.mkTheoryWithSignature(newSig).withAxioms(newAxioms)).withScopes(newScopes)
+
+        }
+
+        newProblemState
     }
     
     override val name: String = "IntegerToBitVector Transformer"

--- a/core/src/main/scala/fortress/transformers/IntegerToBitVectorTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/IntegerToBitVectorTransformer.scala
@@ -6,20 +6,27 @@ import fortress.operations.LiaChecker
 import fortress.util.Errors
 import fortress.operations.TermOps._
 import fortress.problemstate.ProblemState
+import fortress.problemstate.ExactScope
+import fortress.problemstate.Scope
 
 /** Replaces integers with bitvectors of the given bitwidth. */
 object IntegerToBitVectorTransformer extends ProblemStateTransformer {
     
     override def apply(problemState: ProblemState): ProblemState = {
         if (problemState.scopes.contains(IntSort)) {
-            val bitwidth = problemState.scopes(IntSort)  // Scope
+            val numValues = problemState.scopes(IntSort).size
+            // Do log_2 of numValues to find bitwidth
+            val bitwidth: Int = math.round(math.ceil(math.log(numValues) / math.log(2))).toInt
+            // We may store more values than initially given
+            val totalValues = math.pow(2, bitwidth).toInt
+
             val newAxioms = problemState.theory.axioms.map( axiom => {
-                if( !axiom.isLia ) axiom.intToBitVector(bitwidth.size)
+                if( !axiom.isLia ) axiom.intToBitVector(bitwidth)
                 else axiom
             })
-            val newSig = problemState.theory.signature.replaceIntegersWithBitVectors(bitwidth.size)
+            val newSig = problemState.theory.signature.replaceIntegersWithBitVectors(bitwidth)
             // remove IntSort from the scopes map
-            val newScopes = problemState.scopes.filter(x => !(x._1 == IntSort))
+            val newScopes: Map[Sort, Scope] = problemState.scopes.filter(x => !(x._1 == IntSort)) + (BitVectorSort(bitwidth) -> ExactScope(totalValues))
             // this is the return value
             problemState.withTheory(Theory.mkTheoryWithSignature(newSig).withAxioms(newAxioms)).withScopes(newScopes)
 

--- a/core/src/test/scala/transformers/IntegerToBitVectorTransformerTest.scala
+++ b/core/src/test/scala/transformers/IntegerToBitVectorTransformerTest.scala
@@ -8,13 +8,13 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
         val theory = Theory.empty
             .withAxiom(Not(IntegerLiteral(1) === IntegerLiteral(2)))
 
-        val problemState = ProblemState(theory,Map(IntSort -> ExactScope(4)))
+        val problemState = ProblemState(theory,Map(IntSort -> ExactScope(16)))
 
         val expected = ProblemState(
             Theory.empty
             .withAxiom(Not(
                 BitVectorLiteral(value = 1, bitwidth = 4) === BitVectorLiteral(value = 2, bitwidth = 4))),
-            Map.empty
+            Map.empty + (BitVectorSort(4) -> ExactScope(16))
         )
 
         val transformer = IntegerToBitVectorTransformer
@@ -28,13 +28,13 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
             .withConstant(i of IntSort)
             .withAxiom(i === IntegerLiteral(5))
 
-        val problemState = ProblemState(theory,Map(IntSort->ExactScope(4)))
+        val problemState = ProblemState(theory,Map(IntSort->ExactScope(16)))
 
         val expected = ProblemState(
             Theory.empty
             .withConstant(i of BitVectorSort(4))
             .withAxiom(i === BitVectorLiteral(value = 5, bitwidth = 4)),
-            Map.empty
+            Map.empty + (BitVectorSort(4) -> ExactScope(16))
         )
         
         val transformer = IntegerToBitVectorTransformer
@@ -49,13 +49,13 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
             .withConstants(i of IntSort, j of IntSort)
             .withAxiom(BuiltinApp(IntPlus, i, j) === BuiltinApp(IntPlus, i, j))
 
-        val problemState = ProblemState(theory,Map(IntSort->ExactScope(4)))
+        val problemState = ProblemState(theory,Map(IntSort->ExactScope(16)))
         
         val expected = ProblemState(
             Theory.empty
             .withConstants(i of BitVectorSort(4), j of BitVectorSort(4))
             .withAxiom(BuiltinApp(BvPlus, i, j) === BuiltinApp(BvPlus, i, j)),
-            Map.empty
+            Map.empty + (BitVectorSort(4) -> ExactScope(16))
         )
 
         val transformer = IntegerToBitVectorTransformer
@@ -72,7 +72,7 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
             .withConstant(c of A)
             .withAxiom(App("f", c, IntegerLiteral(5)) === IntegerLiteral(7))
 
-        val problemState = ProblemState(theory,Map(IntSort->ExactScope(4)))
+        val problemState = ProblemState(theory,Map(IntSort->ExactScope(16)))
         
         val expected = ProblemState(
             Theory.empty
@@ -80,7 +80,7 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
             .withFunctionDeclaration(FuncDecl("f", A, BitVectorSort(4), BitVectorSort(4)))
             .withConstant(c of A)
             .withAxiom(App("f", c, BitVectorLiteral(value = 5, bitwidth = 4)) === BitVectorLiteral(value = 7, bitwidth = 4)),
-            Map.empty
+            Map.empty + (BitVectorSort(4) -> ExactScope(16))
         )
 
         val transformer = IntegerToBitVectorTransformer
@@ -95,13 +95,13 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
             .withFunctionDeclaration(FuncDecl("f", IntSort, IntSort, IntSort))
             .withAxiom(Forall( Seq(x of IntSort, y of IntSort), BuiltinApp(IntPlus, x, y) === App("f", x, y)))
 
-        val problemState = ProblemState(theory,Map(IntSort->ExactScope(4)))
+        val problemState = ProblemState(theory,Map(IntSort->ExactScope(16)))
         
         val expected = ProblemState(
             Theory.empty
             .withFunctionDeclaration(FuncDecl("f", BitVectorSort(4), BitVectorSort(4), BitVectorSort(4)))
             .withAxiom(Forall( Seq(x of BitVectorSort(4), y of BitVectorSort(4)), BuiltinApp(BvPlus, x, y) === App("f", x, y))),
-            Map.empty
+            Map.empty + (BitVectorSort(4) -> ExactScope(16))
         )
 
         val transformer = IntegerToBitVectorTransformer
@@ -123,7 +123,7 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
                 .withAxiom(Forall( Seq(x of IntSort, y of IntSort), BuiltinApp(IntPlus, x, y) === App("f", x, y)))
                 .withAxiom(axiom1)
 
-        val problemState = ProblemState(theory,Map(IntSort->ExactScope(4)))
+        val problemState = ProblemState(theory,Map(IntSort->ExactScope(16)))
 
         val expected = ProblemState(
             Theory.empty
@@ -131,7 +131,7 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
                     .withFunctionDeclaration(FuncDecl("g", UnBoundedIntSort, UnBoundedIntSort, UnBoundedIntSort))
                     .withAxiom(Forall( Seq(x of BitVectorSort(4), y of BitVectorSort(4)), BuiltinApp(BvPlus, x, y) === App("f", x, y)))
                     .withAxiom(axiom1),
-                    Map.empty
+                    Map.empty + (BitVectorSort(4) -> ExactScope(16))
         )
 
         val transformer = IntegerToBitVectorTransformer

--- a/core/src/test/scala/transformers/IntegerToBitVectorTransformerTest.scala
+++ b/core/src/test/scala/transformers/IntegerToBitVectorTransformerTest.scala
@@ -137,4 +137,21 @@ class IntegerToBitVectorTransformerTest extends UnitSuite {
         val transformer = IntegerToBitVectorTransformer
         transformer(problemState) should be (expected)
     }
+
+    test("BoundedIntSort"){
+        val theory = Theory.empty
+            .withAxiom(Not(IntegerLiteral(1) === IntegerLiteral(2)))
+
+        val problemState = ProblemState(theory,Map(BoundedIntSort -> ExactScope(16)))
+
+        val expected = ProblemState(
+            Theory.empty
+            .withAxiom(Not(
+                BitVectorLiteral(value = 1, bitwidth = 4) === BitVectorLiteral(value = 2, bitwidth = 4))),
+            Map.empty + (BitVectorSort(4) -> ExactScope(16))
+        )
+
+        val transformer = IntegerToBitVectorTransformer
+        transformer(problemState) should be (expected)
+    }
 }


### PR DESCRIPTION
IntegerToBitvector transformer now properly adds a scope.

IntSort and BoundedIntSort are now expected to give the number of values as a scope, not a bitwidth.