### PR TITLE
Fix bug blocking SMTLIB+ output in Portus

### DIFF
--- a/core/src/main/scala/fortress/problemstate/ProblemState.scala
+++ b/core/src/main/scala/fortress/problemstate/ProblemState.scala
@@ -70,8 +70,12 @@ object ProblemState {
     
     def apply(theory: Theory, scopes: Map[Sort, Scope]): ProblemState = {
         // Compute the scopes for enum sorts
+        // Copy whether the scope is fixed from the regular scope if applicable for compatibility
+        def isFixed(sort: Sort) =
+            if (scopes contains sort) scopes(sort).isExact
+            else false
         val enumScopes = theory.signature.enumConstants.map {
-            case (sort, enumValues) => sort -> ExactScope(enumValues.size)
+            case (sort, enumValues) => sort -> ExactScope(enumValues.size, isFixed(sort))
         }.toMap
 
         // Check there is no conflict between the enum scopes and the provided scopes


### PR DESCRIPTION
Outputting SMTLIB+ in Portus was running into the `Conflict between enums and provide scopes` error.  The cause of this is that in `ProblemState.apply`, we always set the generated enum scopes' `fixed` attribute to false, which caused this error if there is a fixed sort with enum constants in the model. This PR fixes it by copying whether the enum sorts are fixed from the normal scopes if applicable.