### PR TITLE
Fix mismatched AndList/OrList in SMTLIB parsing

### DIFF
--- a/core/src/main/scala/fortress/solverinterface/SMTLIBCLISession.scala
+++ b/core/src/main/scala/fortress/solverinterface/SMTLIBCLISession.scala
@@ -127,7 +127,7 @@ trait SMTLIBCLISession extends solver {
             def updateFunc(func: Term): Term = func match {
                 case IfThenElse(a, b, c) => IfThenElse(updateFunc(a), updateFunc(b), updateFunc(c))
                 case AndList(args) => AndList(args.map(updateFunc))
-                case OrList(args) => AndList(args.map(updateFunc))
+                case OrList(args) => OrList(args.map(updateFunc))
                 case (distinct: Distinct) => updateFunc(distinct.asPairwiseNotEquals)
                 case Implication(left, right) => Implication(updateFunc(left), updateFunc(right))
                 case Iff(p, q) => Iff(updateFunc(p), updateFunc(q))


### PR DESCRIPTION
I'm pretty sure this was just a typo. It was causing issues with the evaluator in Portus.