### PR TITLE
Kill Z3 on process shutdown

### DIFF
--- a/core/src/main/scala/fortress/solverinterface/ProcessSession.scala
+++ b/core/src/main/scala/fortress/solverinterface/ProcessSession.scala
@@ -8,7 +8,12 @@ class ProcessSession(processArgs: java.util.List[String]) extends AutoCloseable 
     private val process: Process = new ProcessBuilder(processArgs).start()
     private val in: BufferedWriter = new BufferedWriter(new OutputStreamWriter(process.getOutputStream))
     private val out: BufferedReader = new BufferedReader(new InputStreamReader(process.getInputStream))
-    
+
+    private val closeThread: Thread = new Thread(() => {
+        process.destroyForcibly()
+    })
+    Runtime.getRuntime.addShutdownHook(closeThread)
+
     def flush(): Unit = in.flush()
     def write(str: String): Unit = in.write(str)
     def readLine(): String = out.readLine()
@@ -21,6 +26,7 @@ class ProcessSession(processArgs: java.util.List[String]) extends AutoCloseable 
         in.close()
         out.close()
         process.destroy()
+        Runtime.getRuntime.removeShutdownHook(closeThread)
     }
     
 }


### PR DESCRIPTION
This should at least partially address the longstanding issue where the Z3 process would have to be manually killed.