### PR TITLE
Copy scope exactness when computing enum scopes

### DIFF
--- a/core/src/main/scala/fortress/problemstate/ProblemState.scala
+++ b/core/src/main/scala/fortress/problemstate/ProblemState.scala
@@ -78,12 +78,15 @@ object ProblemState {
     
     def apply(theory: Theory, scopes: Map[Sort, Scope]): ProblemState = {
         // Compute the scopes for enum sorts
-        // Copy whether the scope is fixed from the regular scope if applicable for compatibility
+        // Copy whether the scope is fixed and its exactness from the regular scope if applicable for compatibility
         def isFixed(sort: Sort) =
             if (scopes contains sort) scopes(sort).isUnchanging
             else true
+        def makeScopeWithExactness(sort: Sort, size: Int, isUnchanging: Boolean) =
+            if ((scopes contains sort) && scopes(sort).isExact) ExactScope(size, isUnchanging)
+            else NonExactScope(size, isUnchanging)
         val enumScopes = theory.signature.enumConstants.map {
-            case (sort, enumValues) => sort -> ExactScope(enumValues.size, isFixed(sort))
+            case (sort, enumValues) => sort -> makeScopeWithExactness(sort, enumValues.size, isFixed(sort))
         }.toMap
 
         // Check there is no conflict between the enum scopes and the provided scopes


### PR DESCRIPTION
To avoid the `Conflict between enums and provide scopes` error, we copy whether the scope is exact or non-exact in `ProblemState.apply` like how we copy whether it's unchanging or not. This fixes the error in Portus when outputting post-Fortress SMTLIB to file, and also actually *did* fix one exception in the expert models.