### PR TITLE
Add ScalarQuantifierSimplifier transformer

### DIFF
--- a/core/src/main/scala/fortress/compiler/FortressCompilers.scala
+++ b/core/src/main/scala/fortress/compiler/FortressCompilers.scala
@@ -26,7 +26,7 @@ abstract class ConstantsMethodCompiler() extends LogicCompiler {
         transformerSequence += new SymmetryBreakingTransformer(MonoFirstThenFunctionsFirstAnyOrder, DefaultSymmetryBreaker)
         transformerSequence += StandardQuantifierExpansionTransformer
         transformerSequence += RangeFormulaStandardTransformer
-        transformerSequence += new SimplifyTransformer
+        transformerSequence += SimplifyWithScalarQuantifiersTransformer
         transformerSequence += DomainEliminationTransformer
         transformerSequence.toList
     }
@@ -49,7 +49,7 @@ abstract class DatatypeMethodNoRangeCompiler() extends LogicCompiler {
         transformerSequence += IntegerToBitVectorTransformer      
         transformerSequence += NoOverflowBVTransformer
         transformerSequence += new SymmetryBreakingTransformer(MonoFirstThenFunctionsFirstAnyOrder, DefaultSymmetryBreaker)
-        transformerSequence += new SimplifyTransformer
+        transformerSequence += SimplifyWithScalarQuantifiersTransformer
         transformerSequence += DatatypeTransformer
         transformerSequence.toList
     }
@@ -73,7 +73,7 @@ abstract class DatatypeMethodWithRangeCompiler() extends LogicCompiler {
         transformerSequence += NoOverflowBVTransformer
         transformerSequence += new SymmetryBreakingTransformer(MonoFirstThenFunctionsFirstAnyOrder, DefaultSymmetryBreaker)
         transformerSequence += RangeFormulaStandardTransformer
-        transformerSequence += new SimplifyTransformer
+        transformerSequence += SimplifyWithScalarQuantifiersTransformer
         transformerSequence += DatatypeTransformer
         transformerSequence.toList
     }
@@ -97,7 +97,7 @@ abstract class DatatypeMethodNoRangeEUFCompiler() extends LogicCompiler {
         transformerSequence += SkolemizeTransformer
         transformerSequence += new SymmetryBreakingTransformer(MonoFirstThenFunctionsFirstAnyOrder, DefaultSymmetryBreaker)
         transformerSequence += StandardQuantifierExpansionTransformer
-        transformerSequence += new SimplifyTransformer
+        transformerSequence += SimplifyWithScalarQuantifiersTransformer
         transformerSequence += DatatypeTransformer
         transformerSequence.toList
     }
@@ -122,7 +122,7 @@ abstract class DatatypeMethodWithRangeEUFCompiler() extends LogicCompiler {
         transformerSequence += new SymmetryBreakingTransformer(MonoFirstThenFunctionsFirstAnyOrder, DefaultSymmetryBreaker)
         transformerSequence += StandardQuantifierExpansionTransformer
         transformerSequence += RangeFormulaStandardTransformer
-        transformerSequence += new SimplifyTransformer
+        transformerSequence += SimplifyWithScalarQuantifiersTransformer
         transformerSequence += DatatypeTransformer
         transformerSequence.toList
     }

--- a/core/src/main/scala/fortress/compiler/FortressCompilers.scala
+++ b/core/src/main/scala/fortress/compiler/FortressCompilers.scala
@@ -24,9 +24,10 @@ abstract class ConstantsMethodCompiler() extends LogicCompiler {
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
         transformerSequence += new SymmetryBreakingTransformer(MonoFirstThenFunctionsFirstAnyOrder, DefaultSymmetryBreaker)
+        transformerSequence += SimplifyWithScalarQuantifiersTransformer
         transformerSequence += StandardQuantifierExpansionTransformer
         transformerSequence += RangeFormulaStandardTransformer
-        transformerSequence += SimplifyWithScalarQuantifiersTransformer
+        transformerSequence += new SimplifyTransformer
         transformerSequence += DomainEliminationTransformer
         transformerSequence.toList
     }
@@ -96,8 +97,9 @@ abstract class DatatypeMethodNoRangeEUFCompiler() extends LogicCompiler {
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
         transformerSequence += new SymmetryBreakingTransformer(MonoFirstThenFunctionsFirstAnyOrder, DefaultSymmetryBreaker)
-        transformerSequence += StandardQuantifierExpansionTransformer
         transformerSequence += SimplifyWithScalarQuantifiersTransformer
+        transformerSequence += StandardQuantifierExpansionTransformer
+        transformerSequence += new SimplifyTransformer
         transformerSequence += DatatypeTransformer
         transformerSequence.toList
     }
@@ -120,9 +122,10 @@ abstract class DatatypeMethodWithRangeEUFCompiler() extends LogicCompiler {
         transformerSequence += NnfTransformer
         transformerSequence += SkolemizeTransformer
         transformerSequence += new SymmetryBreakingTransformer(MonoFirstThenFunctionsFirstAnyOrder, DefaultSymmetryBreaker)
+        transformerSequence += SimplifyWithScalarQuantifiersTransformer
         transformerSequence += StandardQuantifierExpansionTransformer
         transformerSequence += RangeFormulaStandardTransformer
-        transformerSequence += SimplifyWithScalarQuantifiersTransformer
+        transformerSequence += new SimplifyTransformer
         transformerSequence += DatatypeTransformer
         transformerSequence.toList
     }

--- a/core/src/main/scala/fortress/operations/ScalarQuantifierSimplifier.scala
+++ b/core/src/main/scala/fortress/operations/ScalarQuantifierSimplifier.scala
@@ -1,0 +1,87 @@
+package fortress.operations
+
+import fortress.msfol._
+import fortress.operations.TermOps._
+
+/**
+  * Simplify:
+  *   "forall x: A | x = e => f" to "e = e => f[e/x]"
+  *   "exists x: A | x = e && f" to "e = e && f[e/x]"
+  * There are redundant equalities left over; a further simplifier should take care of them.
+  */
+object ScalarQuantifierSimplifier extends NaturalTermRecursion {
+    def simplify(term: Term): Term = naturalRecur(term)
+
+    override val exceptionalMappings: PartialFunction[Term, Term] = {
+        case Forall(vars, or @ OrList(_)) => processForall(vars, extractDisjuncts(naturalRecur(or)))
+        case Exists(vars, and @ AndList(_)) => processExists(vars, extractConjuncts(naturalRecur(and)))
+    }
+
+    private def extractDisjuncts(term: Term): Seq[Term] = term match {
+        case OrList(disjuncts) => disjuncts flatMap extractDisjuncts
+        case Not(negated) => extractConjuncts(negated) map negate  // de Morgan's laws
+        case _ => Seq(term)
+    }
+
+    private def extractConjuncts(term: Term): Seq[Term] = term match {
+        case AndList(conjuncts) => conjuncts flatMap extractConjuncts
+        case Not(negated) => extractDisjuncts(negated) map negate  // de Morgan's laws
+        case _ => Seq(term)
+    }
+
+    private def negate(term: Term) = term match {
+        case Not(sub) => sub
+        case _ => Not(term)
+    }
+
+    private def processForall(vars: Seq[AnnotatedVar], disjuncts: Seq[Term]): Term = {
+        // for each var x, if "x != e" appears in the disjuncts, substitute e for x in all disjuncts
+        // note that x must not appear free in e
+        var remainingDisjuncts = disjuncts
+        val remainingVars = vars filter { case AnnotatedVar(variable, _) =>
+            val substitutableExprs = remainingDisjuncts collect {
+                case Not(Eq(v, e)) if v == variable
+                    && !(e.freeVarConstSymbols contains variable) => e
+                case Not(Eq(e, v)) if v == variable
+                    && !(e.freeVarConstSymbols contains variable) => e
+            }
+            if (substitutableExprs.nonEmpty) {
+                // just pick the first one
+                val expr = substitutableExprs.head
+                remainingDisjuncts = substituteAll(remainingDisjuncts, variable, expr)
+            }
+            substitutableExprs.isEmpty
+        }
+
+        val body = Or.smart(remainingDisjuncts)
+        if (remainingVars.isEmpty) body
+        else Forall(remainingVars, body)
+    }
+
+    private def processExists(vars: Seq[AnnotatedVar], conjuncts: Seq[Term]): Term = {
+        // for each var x, if "x = e" appears in the conjuncts, substitute e for x in all conjuncts
+        // note that x must not appear free in e
+        var remainingConjuncts = conjuncts
+        val remainingVars = vars filter { case AnnotatedVar(variable, _) =>
+            val substitutableExprs = remainingConjuncts collect {
+                case Eq(v, e) if v == variable
+                    && !(e.freeVarConstSymbols contains variable) => e
+                case Eq(e, v) if v == variable
+                    && !(e.freeVarConstSymbols contains variable) => e
+            }
+            if (substitutableExprs.nonEmpty) {
+                // just pick the first one
+                val expr = substitutableExprs.head
+                remainingConjuncts = substituteAll(remainingConjuncts, variable, expr)
+            }
+            substitutableExprs.isEmpty
+        }
+
+        val body = And.smart(remainingConjuncts)
+        if (remainingVars.isEmpty) body
+        else Exists(remainingVars, body)
+    }
+
+    private def substituteAll(terms: Seq[Term], variable: Var, expr: Term): Seq[Term] =
+        terms map { _.substitute(variable, expr) }
+}

--- a/core/src/main/scala/fortress/transformers/SimplifyWithScalarQuantifiersTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/SimplifyWithScalarQuantifiersTransformer.scala
@@ -1,0 +1,15 @@
+package fortress.transformers
+
+import fortress.msfol._
+import fortress.operations._
+import fortress.operations.TermOps._
+import fortress.operations.TheoryOps._
+
+object SimplifyWithScalarQuantifiersTransformer extends TheoryTransformer {
+    override def apply(theory: Theory): Theory = theory
+        .mapAxioms(_.simplify)  // necessary before ScalarQuantifierSimplifier
+        .mapAxioms(ScalarQuantifierSimplifier.simplify)
+        .mapAxioms(_.simplify)  // clean up anything introduced
+
+    override def name: String = "Simplify Scalar Quantifiers Transformer"
+}


### PR DESCRIPTION
`ScalarQuantifierSimplifier` (for lack of a better name) performs the following transformation for any sort `S`, scalar expression `e`, and formula `f`:
```
"forall x: S . x = e => f"  maps to  f[e/x]
"exists x: S . x = e && f"  maps to  f[e/x]
```
It tries to be smart about nested ands/ors and DML. It needs a simplifier before and after, so I thought it was easiest to just have it replace the simplifier in the list of transformers.

I wasn't sure which compilers to use the simplifier in (e.g. do some have to remain unchanged from prior papers?), so I just used it in the ones that Portus can use.