### PR TITLE
Fix enum elimination in definitions

### DIFF
--- a/core/src/main/scala/fortress/transformers/EnumEliminationTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/EnumEliminationTransformer.scala
@@ -29,11 +29,11 @@ object EnumEliminationTransformer extends ProblemStateTransformer {
         // definitions are basically untested
         for(cDef <- theory.signature.constantDefinitions){
             newSig = newSig.withoutConstantDefinition(cDef)
-            newSig = newSig.withConstantDefinition(cDef.mapBody(_.eliminateDomainElementsEnums))
+            newSig = newSig.withConstantDefinition(cDef.mapBody(_.eliminateEnumValues(mapping)))
         }
         for(fDef <- theory.signature.functionDefinitions){
             newSig = newSig.withoutFunctionDefinition(fDef)
-            newSig = newSig.withFunctionDefinition(fDef.mapBody(_.eliminateDomainElementsEnums))
+            newSig = newSig.withFunctionDefinition(fDef.mapBody(_.eliminateEnumValues(mapping)))
         }
         
         val newTheory = Theory(newSig, newAxioms)


### PR DESCRIPTION
`EnumEliminationTransformer` was calling `eliminationDomainElementsEnums` on definition bodies, which replaces domain elements with enums, rather than `eliminateEnumValues`, which replaces enums with domain elements. The second one should probably be what we're doing.