### PR TITLE
Apply simplifier transformers to definition bodies

### DIFF
--- a/core/src/main/scala/fortress/msfol/Signature.scala
+++ b/core/src/main/scala/fortress/msfol/Signature.scala
@@ -50,7 +50,9 @@ case class Signature private (
     
     @varargs
     def withSorts(sorts: Sort*): Signature = withSorts(sorts.asJava)
-    
+
+    def mapSorts(f: Sort => Sort): Signature = copy(sorts = sorts map f)
+
     def withFunctionDeclaration(fdecl: FuncDecl): Signature = {
         assertFuncDeclConsistent(fdecl)
         this.copy(functionDeclarations= functionDeclarations + fdecl)
@@ -74,7 +76,10 @@ case class Signature private (
     
     @varargs
     def withFunctionDeclarations(fdecls: FuncDecl*): Signature = withFunctionDeclarations(fdecls.asJava)
-    
+
+    def mapFunctionDeclarations(f: FuncDecl => FuncDecl): Signature =
+        copy(functionDeclarations = functionDeclarations map f)
+
     def withConstantDeclaration(c: AnnotatedVar): Signature = {
         assertConstDeclConsistent(c);
         this.copy(constantDeclarations = constantDeclarations + c)
@@ -98,7 +103,10 @@ case class Signature private (
     
     @varargs
     def withConstantDeclarations(constants: AnnotatedVar*): Signature = withConstantDeclarations(constants.asJava)
-    
+
+    def mapConstantDeclarations(f: AnnotatedVar => AnnotatedVar): Signature =
+        copy(constantDeclarations = constantDeclarations map f)
+
     def withConstantDefinition(cDef: ConstantDefinition): Signature = {
         assertConstantDefnConsistent(cDef)
         this.copy(constantDefinitions = constantDefinitions + cDef)
@@ -123,6 +131,9 @@ case class Signature private (
     }
 
     def withoutFunctionDefinitions(): Signature = copy(functionDefinitions = Set.empty)
+
+    def mapConstantDefinitions(f: ConstantDefinition => ConstantDefinition): Signature =
+        copy(constantDefinitions = constantDefinitions map f)
 
     def withEnumSort(t: Sort, values: Seq[EnumValue]) = {
         // TODO more consistency checking
@@ -183,6 +194,9 @@ case class Signature private (
     }
 
     def withoutFunctionDefinitions(funcDefs: FunctionDefinition*): Signature = withoutFunctionDefinitions(funcDefs.asJava)
+
+    def mapFunctionDefinitions(f: FunctionDefinition => FunctionDefinition): Signature =
+        copy(functionDefinitions = functionDefinitions map f)
 
     // TypeChecking
     

--- a/core/src/main/scala/fortress/operations/TheoryOps.scala
+++ b/core/src/main/scala/fortress/operations/TheoryOps.scala
@@ -22,6 +22,10 @@ case class TheoryOps private(theory: Theory) {
 
     def withoutAxioms: Theory = Theory(theory.signature, Set.empty)
 
+    def mapAllTerms(f: Term => Term): Theory = Theory(
+        theory.signature.mapFunctionDefinitions(_.mapBody(f)).mapConstantDefinitions(_.mapBody(f)),
+        theory.axioms.map(f))
+
     def smtlib: String = {
         val writer = new java.io.StringWriter
         val converter = new SmtlibConverter(writer)

--- a/core/src/main/scala/fortress/transformers/SimplifyTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/SimplifyTransformer.scala
@@ -10,7 +10,7 @@ import fortress.problemstate.ProblemState
 class SimplifyTransformer extends ProblemStateTransformer {
 
     override def apply(problemState: ProblemState): ProblemState =  {
-      problemState.copy(theory = problemState.theory.mapAxioms(_.simplify))
+      problemState.copy(theory = problemState.theory.mapAllTerms(_.simplify))
     }
 
     override def name: String = "Simplify Transformer"

--- a/core/src/main/scala/fortress/transformers/SimplifyTransformer2.scala
+++ b/core/src/main/scala/fortress/transformers/SimplifyTransformer2.scala
@@ -18,7 +18,7 @@ class SimplifyTransformer2 extends ProblemStateTransformer {
     
     override def apply(problemState: ProblemState): ProblemState =  {
       problemState.copy(
-        theory = problemState.theory.mapAxioms(Simplifier2.simplify)
+        theory = problemState.theory.mapAllTerms(Simplifier2.simplify)
       )
     }
     

--- a/core/src/main/scala/fortress/transformers/SimplifyWithRangeTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/SimplifyWithRangeTransformer.scala
@@ -12,7 +12,7 @@ class SimplifyWithRangeTransformer extends ProblemStateTransformer {
         val theory = problemState.theory
         val rangeRestricts = problemState.rangeRestrictions
 
-        val newTheory = theory.mapAxioms(_.simplifyWithRange(rangeRestricts))
+        val newTheory = theory.mapAllTerms(_.simplifyWithRange(rangeRestricts))
         // val newTheory = theory.mapAxioms(_.simplify)
         // ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapplyInterp, distinctConstants)
         problemState.copy(theory=newTheory)

--- a/core/src/main/scala/fortress/transformers/SimplifyWithScalarQuantifiersTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/SimplifyWithScalarQuantifiersTransformer.scala
@@ -9,9 +9,9 @@ import fortress.problemstate.ProblemState
 object SimplifyWithScalarQuantifiersTransformer extends ProblemStateTransformer {
     override def apply(problemState: ProblemState): ProblemState = {
         val newTheory = problemState.theory
-        .mapAxioms(_.simplify)  // necessary before ScalarQuantifierSimplifier
-        .mapAxioms(ScalarQuantifierSimplifier.simplify)
-        .mapAxioms(_.simplify)  // clean up anything introduced
+        .mapAllTerms(_.simplify)  // necessary before ScalarQuantifierSimplifier
+        .mapAllTerms(ScalarQuantifierSimplifier.simplify)
+        .mapAllTerms(_.simplify)  // clean up anything introduced
 
         problemState.copy(
             theory = newTheory


### PR DESCRIPTION
The simplifiers were being applied to axioms but not to definition bodies. Since we might have significant chunks of the model in definition bodies, they should be simplified too. This adds a `mapAllTerms` theory operation that maps all axioms and definition bodies at once as a drop-in replacement for `mapAxioms`, and uses it in the simplifier transformers.