### PR TITLE
Optimize quantifiers with anti-prenex normal form

### DIFF
--- a/core/src/main/scala/fortress/compiler/FortressCompilers.scala
+++ b/core/src/main/scala/fortress/compiler/FortressCompilers.scala
@@ -27,10 +27,9 @@ abstract class ConstantsMethodCompiler() extends LogicCompiler {
         transformerSequence += IfLiftingTransformer
         transformerSequence += NnfTransformer
 
-        // eliminates the introduction of some skolem functions, but needs
-        // to come after nnf
+        transformerSequence += MaxAlphaRenamingTransformer
+        // eliminates the introduction of some skolem functions, but needs to come after nnf and max alpha renaming
         transformerSequence += SimplifyWithScalarQuantifiersTransformer
-
         transformerSequence += AntiPrenexTransformer
 
         transformerSequence += SkolemizeTransformer
@@ -67,11 +66,11 @@ abstract class ConstantsClaessenCompiler() extends LogicCompiler {
         transformerSequence += IfLiftingTransformer
         transformerSequence += NnfTransformer
 
-        // eliminates the introduction of some skolem functions, but needs
-        // to come after nnf
+        transformerSequence += MaxAlphaRenamingTransformer
+        // eliminates the introduction of some skolem functions, but needs to come after nnf and max alpha renaming
         transformerSequence += SimplifyWithScalarQuantifiersTransformer
+        transformerSequence += AntiPrenexTransformer
 
-        
         transformerSequence += SkolemizeTransformer
 
         transformerSequence += new SymmetryBreakingTransformer(SymmetryBreakingOptions(
@@ -110,8 +109,12 @@ abstract class DatatypeMethodNoRangeCompiler() extends LogicCompiler {
         // transformerSequence += IntegerToBitVectorTransformer  
 
         // nnf needs to help with SimplifyWithScalarQuantifiersTransformer
-        transformerSequence += NnfTransformer        
+        transformerSequence += NnfTransformer
+
+        transformerSequence += MaxAlphaRenamingTransformer
+        // eliminates the introduction of some skolem functions, but needs to come after nnf and max alpha renaming
         transformerSequence += SimplifyWithScalarQuantifiersTransformer
+        transformerSequence += AntiPrenexTransformer
 
         transformerSequence += new SymmetryBreakingTransformer(SymmetryBreakingOptions(
             selectionHeuristic = MonoFirstThenFunctionsFirstAnyOrder,
@@ -149,7 +152,11 @@ abstract class DatatypeMethodWithRangeCompiler() extends LogicCompiler {
         
         // nnf needs to help with SimplifyWithScalarQuantifiersTransformer
         transformerSequence += NnfTransformer
+
+        transformerSequence += MaxAlphaRenamingTransformer
+        // eliminates the introduction of some skolem functions, but needs to come after nnf and max alpha renaming
         transformerSequence += SimplifyWithScalarQuantifiersTransformer
+        transformerSequence += AntiPrenexTransformer
 
         transformerSequence += new SymmetryBreakingTransformer(SymmetryBreakingOptions(
             selectionHeuristic = MonoFirstThenFunctionsFirstAnyOrder,
@@ -187,10 +194,11 @@ abstract class DatatypeMethodNoRangeEUFCompiler() extends LogicCompiler {
         transformerSequence += IfLiftingTransformer
         transformerSequence += NnfTransformer
 
-        // eliminates the introduction of some skolem functions, but needs
-        // to come after nnf
+        transformerSequence += MaxAlphaRenamingTransformer
+        // eliminates the introduction of some skolem functions, but needs to come after nnf and max alpha renaming
         transformerSequence += SimplifyWithScalarQuantifiersTransformer
-        
+        transformerSequence += AntiPrenexTransformer
+
         transformerSequence += SkolemizeTransformer
       
         transformerSequence += new SymmetryBreakingTransformer(SymmetryBreakingOptions(
@@ -229,9 +237,10 @@ abstract class DatatypeMethodWithRangeEUFCompiler() extends LogicCompiler {
         transformerSequence += IfLiftingTransformer
         transformerSequence += NnfTransformer
 
-        // eliminates the introduction of some skolem functions, but needs
-        // to come after nnf
+        transformerSequence += MaxAlphaRenamingTransformer
+        // eliminates the introduction of some skolem functions, but needs to come after nnf and max alpha renaming
         transformerSequence += SimplifyWithScalarQuantifiersTransformer
+        transformerSequence += AntiPrenexTransformer
 
         transformerSequence += SkolemizeTransformer
 

--- a/core/src/main/scala/fortress/compiler/FortressCompilers.scala
+++ b/core/src/main/scala/fortress/compiler/FortressCompilers.scala
@@ -31,6 +31,8 @@ abstract class ConstantsMethodCompiler() extends LogicCompiler {
         // to come after nnf
         transformerSequence += SimplifyWithScalarQuantifiersTransformer
 
+        transformerSequence += AntiPrenexTransformer
+
         transformerSequence += SkolemizeTransformer
       
         transformerSequence += new SymmetryBreakingTransformer(SymmetryBreakingOptions(
@@ -40,7 +42,6 @@ abstract class ConstantsMethodCompiler() extends LogicCompiler {
             patternOptimization = true,
         ))
 
-        
         transformerSequence += QuantifiersToDefinitionsTransformer
         transformerSequence += StandardQuantifierExpansionTransformer
         transformerSequence += RangeFormulaStandardTransformer

--- a/core/src/main/scala/fortress/compiler/LogicCompiler.scala
+++ b/core/src/main/scala/fortress/compiler/LogicCompiler.scala
@@ -31,6 +31,9 @@ trait LogicCompiler {
                 if(countdown.isExpired) return Left(CompilerError.Timeout)
                 loggers.foreach(_.transformerStarted(transformer))
 
+//                println(s"Theory before ${transformer.name}:\n-----")
+//                println(Dump.theoryToSmtlibTC(pState.theory))
+//                println("-----")
                 val (finalPState, elapsedNano) = measureTime {
                     transformer(pState)
                 }
@@ -40,7 +43,11 @@ trait LogicCompiler {
                 finalPState
             })
         }}
-        
+
+//        println(s"Final theory:\n-----")
+//        println(Dump.theoryToSmtlibTC(finalProblemState.theory))
+//        println("-----")
+
         object Result extends CompilerResult {
             override val theory: Theory = finalProblemState.theory
 

--- a/core/src/main/scala/fortress/operations/MaxAlphaRenaming.scala
+++ b/core/src/main/scala/fortress/operations/MaxAlphaRenaming.scala
@@ -1,0 +1,63 @@
+package fortress.operations
+
+import fortress.data.IntSuffixNameGenerator
+import fortress.msfol._
+
+import scala.collection.mutable
+
+/**
+  * Alpha-rename all quantified variables in a theory such that they do not conflict with each other
+  * (even in unrelated parts of the theory) or any elements of the signature.
+  * Does not modify the signature (other than the bodies of definitions) or any function names.
+  */
+object MaxAlphaRenaming {
+    def rename(theory: Theory): Theory = {
+        val nameGenerator = new IntSuffixNameGenerator(Set(), 0)
+        for (sort <- theory.signature.sorts) nameGenerator.forbidName(sort.name)
+        for (funcDecl <- theory.signature.functionDeclarations) nameGenerator.forbidName(funcDecl.name)
+        for (funcDefn <- theory.signature.functionDefinitions) nameGenerator.forbidName(funcDefn.name)
+        for (constDecl <- theory.signature.constantDeclarations) nameGenerator.forbidName(constDecl.name)
+        for (constDefn <- theory.signature.constantDefinitions) nameGenerator.forbidName(constDefn.name)
+        for (enumConstList <- theory.signature.enumConstants.values)
+            for (enumConst <- enumConstList)
+                nameGenerator.forbidName(enumConst.name)
+
+        val nameMap = mutable.Map[String, String]()
+
+        def mapName(name: String) = nameMap.getOrElse(name, name)
+        def freshName(name: String) = {
+            val newName = nameGenerator.freshName(name)
+            nameMap(name) = newName
+            newName
+        }
+
+        def freshVars(vars: Seq[AnnotatedVar]) = vars map {
+            case AnnotatedVar(Var(name), sort) => AnnotatedVar(Var(freshName(name)), sort)
+        }
+
+        object RenameTerm extends NaturalTermRecursion {
+            override val exceptionalMappings: PartialFunction[Term, Term] = {
+                case Var(name) => Var(mapName(name))
+                case EnumValue(name) => EnumValue(mapName(name))
+
+                case Forall(vars, body) => Forall(freshVars(vars), naturalRecur(body))
+                case Exists(vars, body) => Exists(freshVars(vars), naturalRecur(body))
+            }
+        }
+        def renameTerm(term: Term) = RenameTerm.naturalRecur(term)
+
+        var newSig = theory.signature
+        // these must be done one at a time to avoid our aggressive checking for dependence
+        for (cDef <- theory.signature.constantDefinitions) {
+            newSig = newSig withoutConstantDefinition cDef
+            newSig = newSig withConstantDefinition (cDef mapBody renameTerm)
+        }
+        for (fDef <- theory.signature.functionDefinitions) {
+            newSig = newSig withoutFunctionDefinition fDef
+            newSig = newSig withFunctionDefinition (fDef mapBody renameTerm)
+        }
+
+        val newAxioms = theory.axioms map renameTerm
+        Theory(newSig, newAxioms)
+    }
+}

--- a/core/src/main/scala/fortress/operations/ScalarQuantifierSimplifier.scala
+++ b/core/src/main/scala/fortress/operations/ScalarQuantifierSimplifier.scala
@@ -49,7 +49,6 @@ object ScalarQuantifierSimplifier extends NaturalTermRecursion {
                 // just pick the first one
                 val expr = substitutableExprs.head
                 remainingDisjuncts = substituteAll(remainingDisjuncts, variable, expr)
-//                println("ScalarQuantifierSimplifier eliminated one (forall)!")
             }
             substitutableExprs.isEmpty
         }
@@ -74,7 +73,6 @@ object ScalarQuantifierSimplifier extends NaturalTermRecursion {
                 // just pick the first one
                 val expr = substitutableExprs.head
                 remainingConjuncts = substituteAll(remainingConjuncts, variable, expr)
-//                println("ScalarQuantifierSimplifier eliminated one (exists)!")
             }
             substitutableExprs.isEmpty
         }

--- a/core/src/main/scala/fortress/operations/ScalarQuantifierSimplifier.scala
+++ b/core/src/main/scala/fortress/operations/ScalarQuantifierSimplifier.scala
@@ -49,7 +49,7 @@ object ScalarQuantifierSimplifier extends NaturalTermRecursion {
                 // just pick the first one
                 val expr = substitutableExprs.head
                 remainingDisjuncts = substituteAll(remainingDisjuncts, variable, expr)
-                println("ScalarQuantifierSimplifier eliminated one (forall)!")
+//                println("ScalarQuantifierSimplifier eliminated one (forall)!")
             }
             substitutableExprs.isEmpty
         }
@@ -74,7 +74,7 @@ object ScalarQuantifierSimplifier extends NaturalTermRecursion {
                 // just pick the first one
                 val expr = substitutableExprs.head
                 remainingConjuncts = substituteAll(remainingConjuncts, variable, expr)
-                println("ScalarQuantifierSimplifier eliminated one (exists)!")
+//                println("ScalarQuantifierSimplifier eliminated one (exists)!")
             }
             substitutableExprs.isEmpty
         }

--- a/core/src/main/scala/fortress/operations/ScalarQuantifierSimplifier.scala
+++ b/core/src/main/scala/fortress/operations/ScalarQuantifierSimplifier.scala
@@ -49,6 +49,7 @@ object ScalarQuantifierSimplifier extends NaturalTermRecursion {
                 // just pick the first one
                 val expr = substitutableExprs.head
                 remainingDisjuncts = substituteAll(remainingDisjuncts, variable, expr)
+                println("ScalarQuantifierSimplifier eliminated one (forall)!")
             }
             substitutableExprs.isEmpty
         }
@@ -73,6 +74,7 @@ object ScalarQuantifierSimplifier extends NaturalTermRecursion {
                 // just pick the first one
                 val expr = substitutableExprs.head
                 remainingConjuncts = substituteAll(remainingConjuncts, variable, expr)
+                println("ScalarQuantifierSimplifier eliminated one (exists)!")
             }
             substitutableExprs.isEmpty
         }

--- a/core/src/main/scala/fortress/operations/TermOps.scala
+++ b/core/src/main/scala/fortress/operations/TermOps.scala
@@ -33,8 +33,18 @@ case class TermOps private (term: Term) {
       */
     def nnf: Term = NormalForms.nnf(term)
 
+    /**
+      * Returns the anti-prenex normal form of this term: quantifiers are pushed inwards as far as possible
+      * and rearranged to minimize the size of the quantified formulas.
+      * The term must be in NNF and maximum alpha renaming must have been performed to call this method.
+      */
     def antiPrenex: Term = NormalForms.antiPrenex(term)
 
+    /**
+      * Move universal quantifiers upwards through disjunctions and existential quantifiers upwards
+      * through conjunctions.
+      * The term must be in NNF and maximum alpha renaming must have been performed to call this method.
+      */
     def partialPrenex: Term = NormalForms.partialPrenex(term)
 
     /** Removes all ites from the term by iflifting

--- a/core/src/main/scala/fortress/operations/TermOps.scala
+++ b/core/src/main/scala/fortress/operations/TermOps.scala
@@ -33,6 +33,8 @@ case class TermOps private (term: Term) {
       */
     def nnf: Term = NormalForms.nnf(term)
 
+    def antiPrenex: Term = NormalForms.antiPrenex(term)
+
     /** Removes all ites from the term by iflifting
       * The term must be sanitized to call this method.
       */

--- a/core/src/main/scala/fortress/operations/TermOps.scala
+++ b/core/src/main/scala/fortress/operations/TermOps.scala
@@ -35,6 +35,8 @@ case class TermOps private (term: Term) {
 
     def antiPrenex: Term = NormalForms.antiPrenex(term)
 
+    def partialPrenex: Term = NormalForms.partialPrenex(term)
+
     /** Removes all ites from the term by iflifting
       * The term must be sanitized to call this method.
       */

--- a/core/src/main/scala/fortress/operations/TheoryOps.scala
+++ b/core/src/main/scala/fortress/operations/TheoryOps.scala
@@ -26,6 +26,8 @@ case class TheoryOps private(theory: Theory) {
         theory.signature.mapFunctionDefinitions(_.mapBody(f)).mapConstantDefinitions(_.mapBody(f)),
         theory.axioms.map(f))
 
+    def maxAlphaRenaming: Theory = MaxAlphaRenaming.rename(theory)
+
     def smtlib: String = {
         val writer = new java.io.StringWriter
         val converter = new SmtlibConverter(writer)

--- a/core/src/main/scala/fortress/problemstate/Flags.scala
+++ b/core/src/main/scala/fortress/problemstate/Flags.scala
@@ -8,7 +8,7 @@ import fortress.util.Errors
   * Contains flags for a problem state
   *
   * @param distinctConstants
-  * @param isNNF Is the problem state in negation normal form
+  * @param haveRunNNF Is the problem state in negation normal form
   * @param verbose Debug verbose output should be printed
   */
 case class Flags private(
@@ -17,6 +17,8 @@ case class Flags private(
     haveRunNNF: Boolean = false,
     haveRunIfLifting: Boolean = false,
     haveRunSkolemizer: Boolean = false,
+
+    haveRunMaxAlphaRenaming: Boolean = false,
     
     verbose: Boolean = false,
     

--- a/core/src/main/scala/fortress/transformers/AntiPrenexTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/AntiPrenexTransformer.scala
@@ -1,0 +1,31 @@
+package fortress.transformers
+
+import fortress.operations.TermOps._
+import fortress.operations.TheoryOps._
+import fortress.problemstate.ProblemState
+
+object AntiPrenexTransformer extends ProblemStateTransformer {
+
+    override def name: String = "AntiPrenexTransformer"
+
+    override def apply(problemState: ProblemState): ProblemState = {
+        val theory = problemState.theory
+        var newTheory = theory.mapAllTerms(_.antiPrenex)
+
+        // We only remove a definition before readding it so all its dependencies are in the sig
+        for(cDef <- theory.signature.constantDefinitions){
+            newTheory = newTheory.withoutConstantDefinition(cDef)
+            newTheory = newTheory.withConstantDefinition(cDef.mapBody(_.antiPrenex))
+        }
+        for(fDef <- theory.signature.functionDefinitions){
+            newTheory = newTheory.withoutFunctionDefinition(fDef)
+            newTheory = newTheory.withFunctionDefinition(fDef.mapBody(_.antiPrenex))
+        }
+
+        problemState.copy(
+            theory = newTheory,
+            flags = problemState.flags,
+        )
+    }
+
+}

--- a/core/src/main/scala/fortress/transformers/MaxAlphaRenamingTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/MaxAlphaRenamingTransformer.scala
@@ -1,0 +1,19 @@
+package fortress.transformers
+
+import fortress.operations.TheoryOps._
+import fortress.problemstate.ProblemState
+
+/**
+  * Renames quantified variables in the theory to the maximum extent possible.
+  * See MaxAlphaRenaming.
+  */
+object MaxAlphaRenamingTransformer extends ProblemStateTransformer {
+
+    override def apply(problemState: ProblemState): ProblemState = problemState.copy(
+        theory = problemState.theory.maxAlphaRenaming,
+        flags = problemState.flags.copy(haveRunMaxAlphaRenaming = true),
+    )
+
+    override def name: String = "Max Alpha Renaming Transformer"
+
+}

--- a/core/src/main/scala/fortress/transformers/SimplifyWithScalarQuantifiersTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/SimplifyWithScalarQuantifiersTransformer.scala
@@ -7,15 +7,21 @@ import fortress.problemstate.ProblemState
 import fortress.util.Errors
 
 object SimplifyWithScalarQuantifiersTransformer extends ProblemStateTransformer {
+
     override def apply(problemState: ProblemState): ProblemState = {
         // must have done as much nnf as possible
         if (!problemState.flags.haveRunNNF) {
-            Errors.Internal.preconditionFailed(s"NNF Transformer should be run before SimplifyWithScalarQuantifiersTransformer")
+            Errors.Internal.preconditionFailed(
+                "NNF Transformer should be run before SimplifyWithScalarQuantifiersTransformer")
+        }
+        // max alpha renaming is required for anti-prenex
+        if (!problemState.flags.haveRunMaxAlphaRenaming) {
+            Errors.Internal.preconditionFailed(
+                "Max alpha renaming Transformer should be run before SimplifyWithScalarQuantifiersTransformer")
         }
 
         val newTheory = problemState.theory
             .mapAllTerms(_.simplify)  // necessary before ScalarQuantifierSimplifier
-            .maxAlphaRenaming // necessary for partialPrenex
             .mapAllTerms(_.antiPrenex) // push in as far as possible for a better shot at elimination terms
             .mapAllTerms(_.partialPrenex) // pull back so we can see all the elimination terms
             .mapAllTerms(ScalarQuantifierSimplifier.simplify)
@@ -27,4 +33,5 @@ object SimplifyWithScalarQuantifiersTransformer extends ProblemStateTransformer 
     }
 
     override def name: String = "Simplify Scalar Quantifiers Transformer"
+
 }

--- a/core/src/test/scala/UnitSuite.scala
+++ b/core/src/test/scala/UnitSuite.scala
@@ -15,6 +15,7 @@ object ImplSensitive extends Tag("fortress.tags.ImplSensitive")
 
 trait CommonFunctionalSymbols extends UnitSuite {
     val f = FunctionSymbol("f")
+    val g = FunctionSymbol("g")
     val P = FunctionSymbol("P")
     val Q = FunctionSymbol("Q")
     val R = FunctionSymbol("R")

--- a/core/src/test/scala/operations/NormalFormsTest.scala
+++ b/core/src/test/scala/operations/NormalFormsTest.scala
@@ -63,7 +63,6 @@ class NormalFormsTest extends UnitSuite with CommonSymbols {
             And(p, Exists(y of A, Forall(x of A, Or(And(Not(R(x,x)), S(y)), Q(x,y)))))),
     )
 
-    // TODO: Could also fuzz test, checking that each result is miniscoped
     miniscopeTable foreach { case (input, output) =>
         test(f"miniscope: $input => $output") {
             NormalForms.miniscope(input) should be(output)

--- a/core/src/test/scala/operations/NormalFormsTest.scala
+++ b/core/src/test/scala/operations/NormalFormsTest.scala
@@ -1,0 +1,73 @@
+import fortress.msfol._
+import fortress.operations.NormalForms
+
+class NormalFormsTest extends UnitSuite with CommonSymbols {
+
+    val miniscopeTable: Seq[(Term, Term)] = Seq(
+        (Top, Top),
+        (Bottom, Bottom),
+        (x, x),
+
+        (Forall(x of A, Top), Top),
+        (Forall(x of A, f(x)), Forall(x of A, f(x))),
+        (Forall(x of A, And(f(x), g(x))), And(Forall(x of A, f(x)), Forall(x of A, g(x)))),
+        (Forall(x of A, And(f(x), g(y))), And(Forall(x of A, f(x)), g(y))),
+        (Forall(x of A, And(g(y), f(x))), And(g(y), Forall(x of A, f(x)))),
+        (Forall(x of A, And(f(y), g(z))), And(f(y), g(z))),
+        (Forall(x of A, Or(f(x), g(x))), Forall(x of A, Or(f(x), g(x)))),
+        (Forall(x of A, Or(f(x), g(y))), Or(g(y), Forall(x of A, f(x)))),
+        (Forall(x of A, Or(g(y), f(x))), Or(g(y), Forall(x of A, f(x)))),
+        (Forall(x of A, Or(f(y), g(z))), Or(f(y), g(z))),
+        (Forall(x of A, And(Or(f(x), g(y)), Or(g(x), f(y)))),
+            And(Or(g(y), Forall(x of A, f(x))), Or(f(y), Forall(x of A, g(x))))),
+        (Forall(x of A, Forall(y of A, f(x,y))), Forall(Seq(x of A, y of A), f(x,y))),
+        (Forall(Seq(x of A, y of A), And(f(x), f(y))), And(Forall(x of A, f(x)), Forall(y of A, f(y)))),
+        (Forall(Seq(x of A, y of A), Or(f(x), f(y))), Or(Forall(y of A, f(y)), Forall(x of A, f(x)))),
+        (Forall(Seq(x of A, y of A), Or(f(x), f(x,y), g(x,y))),
+            Forall(x of A, Or(f(x), Forall(y of A, Or(f(x,y), g(x,y)))))),
+        (Forall(x of A, And(Forall(y of A, And(f(x), g(y))), Forall(y of A, And(f(x), g(y))))),
+            And(And(Forall(x of A, f(x)), Forall(y of A, g(y))), And(Forall(x of A, f(x)), Forall(y of A, g(y))))),
+        (Forall(x of A, Exists(y of A, f(x,y))), Forall(x of A, Exists(y of A, f(x,y)))),
+        (Forall(x of A, Exists(y of A, And(f(x), g(y)))),
+            And(Forall(x of A, f(x)), Forall(x of A, Exists(y of A, g(y))))), // redundant because no scope sorting
+        (Forall(x of A, Exists(y of A, Or(f(x,y), g(x,y)))),
+            Forall(x of A, Or(Exists(y of A, f(x,y)), Exists(y of A, g(x,y))))),
+
+        (Exists(x of A, Top), Top),
+        (Exists(x of A, f(x)), Exists(x of A, f(x))),
+        (Exists(x of A, Or(f(x), g(x))), Or(Exists(x of A, f(x)), Exists(x of A, g(x)))),
+        (Exists(x of A, Or(f(x), g(y))), Or(Exists(x of A, f(x)), g(y))),
+        (Exists(x of A, Or(g(y), f(x))), Or(g(y), Exists(x of A, f(x)))),
+        (Exists(x of A, Or(f(y), g(z))), Or(f(y), g(z))),
+        (Exists(x of A, And(f(x), g(x))), Exists(x of A, And(f(x), g(x)))),
+        (Exists(x of A, And(f(x), g(y))), And(g(y), Exists(x of A, f(x)))),
+        (Exists(x of A, And(g(y), f(x))), And(g(y), Exists(x of A, f(x)))),
+        (Exists(x of A, And(f(y), g(z))), And(f(y), g(z))),
+        (Exists(x of A, Or(And(f(x), g(y)), And(g(x), f(y)))),
+            Or(And(g(y), Exists(x of A, f(x))), And(f(y), Exists(x of A, g(x))))),
+        (Exists(x of A, Exists(y of A, f(x,y))), Exists(Seq(x of A, y of A), f(x,y))),
+        (Exists(Seq(x of A, y of A), Or(f(x), f(y))), Or(Exists(x of A, f(x)), Exists(y of A, f(y)))),
+        (Exists(Seq(x of A, y of A), And(f(x), f(y))), And(Exists(y of A, f(y)), Exists(x of A, f(x)))),
+        (Exists(Seq(x of A, y of A), And(f(x), f(x,y), g(x,y))),
+            Exists(x of A, And(f(x), Exists(y of A, And(f(x,y), g(x,y)))))),
+        (Exists(x of A, Or(Exists(y of A, Or(f(x), g(y))), Exists(y of A, Or(f(x), g(y))))),
+            Or(Or(Exists(x of A, f(x)), Exists(y of A, g(y))), Or(Exists(x of A, f(x)), Exists(y of A, g(y))))),
+        (Exists(x of A, Forall(y of A, f(x,y))), Exists(x of A, Forall(y of A, f(x,y)))),
+        (Exists(x of A, Forall(y of A, Or(f(x), g(y)))),
+            Or(Exists(x of A, f(x)), Exists(x of A, Forall(y of A, g(y))))), // redundant because no scope sorting
+        (Exists(x of A, Forall(y of A, And(f(x,y), g(x,y)))),
+            Exists(x of A, And(Forall(y of A, f(x,y)), Forall(y of A, g(x,y))))),
+
+        // Example from Lampert (https://www2.cms.hu-berlin.de/newlogic/webMathematica/Logic/minimizingDNFFOL.pdf)
+        (Exists(y of A, Forall(x of A, And(Or(And(Not(R(x,x)), S(y)), Q(x,y)), p))),
+            And(p, Exists(y of A, Forall(x of A, Or(And(Not(R(x,x)), S(y)), Q(x,y)))))),
+    )
+
+    // TODO: Could also fuzz test, checking that each result is miniscoped
+    miniscopeTable foreach { case (input, output) =>
+        test(f"miniscope: $input => $output") {
+            NormalForms.miniscope(input) should be(output)
+        }
+    }
+
+}

--- a/core/src/test/scala/transformers/SimplifyWithScalarQuantifiersTransformerTest.scala
+++ b/core/src/test/scala/transformers/SimplifyWithScalarQuantifiersTransformerTest.scala
@@ -1,0 +1,29 @@
+import fortress.msfol._
+import fortress.problemstate.ProblemState
+import fortress.transformers.{NnfTransformer, SimplifyWithScalarQuantifiersTransformer}
+
+class SimplifyWithScalarQuantifiersTransformerTest extends UnitSuite with CommonSymbols {
+
+    def simplify(th: Theory): Theory =
+        SimplifyWithScalarQuantifiersTransformer(NnfTransformer(ProblemState(th))).theory
+
+    test("nested quantifier") {
+        val y0 = Var("y_0") // due to max alpha renaming
+
+        val term = Forall(x of A, Or(P(x), Forall(y of A, Or(Q(x, y), !(x === f(y))))))
+        val expected = Forall(y0 of A, Or(Q(f(y0), y0), P(f(y0))))
+
+        val theory = Theory.empty
+            .withSort(A)
+            .withFunctionDeclaration(P from A to BoolSort)
+            .withFunctionDeclarations(Q from (A, A) to BoolSort)
+            .withAxiom(term)
+        val expectedTheory = Theory.empty
+            .withSort(A)
+            .withFunctionDeclaration(P from A to BoolSort)
+            .withFunctionDeclarations(Q from (A, A) to BoolSort)
+            .withAxiom(expected)
+        simplify(theory) should be(expectedTheory)
+    }
+
+}


### PR DESCRIPTION
This implements the algorithm for converting to anti-prenex normal form (in which quantifiers are pushed in as far as possible) from section 2 of this paper: https://www2.cms.hu-berlin.de/newlogic/webMathematica/Logic/minimizingDNFFOL.pdf (minus the CNF/DNF conversion, which could be expensive). Converting to this form helps to minimize the size of the formula after quantifier expansion.

This is implemented in a standalone `AntiPrenexTransformer` which should be run before quantifier expansion. As well, `SimplifyWithScalarQuantifiersTransformer` is enhanced by, before running the optimization, first converting to anti-prenex normal form, then running "partial prenexing" which pulls foralls upwards through disjunctions and exists upwards through conjunctions. Anti-prenexing helps because terms that would let us (partially) eliminate quantifiers might be deeper than the top level, e.g.:
```
                          exists x . (x = y && p(x)) || (x = z && q(x))
(anti-prenexing)     ---> (exists x . x = y && p(x)) || (exists x . x = z && q(x))
(simplify w. sc. q.) ---> p(y) && q(z)
```
Partial prenexing helps because relevant terms letting us eliminate quantifiers might be buried below more quantifiers, e.g.:
```
                          exists x . p(x) && (exists y . f(y) = x && q(x,y))
(partial prenexing)  ---> exists x, y . p(x) && f(y) = x && q(x,y)
(simplify w. sc. q.) ---> exists y . p(f(y)) && q(f(y),y)
```
Anti-prenexing is run again via `AntiPrenexTransformer` after this is done to put it back in anti-prenex normal form to prepare for quantifier expansion.

Note: The transformers are rather heavy due to many AST traversals, mostly since we don't cache the free variables in a term and so we have to traverse the tree to recompute them every time. If this is a bottleneck, consider caching free variables per AST node.