### PR TITLE
Allow closing over function definitions

### DIFF
--- a/core/src/main/scala/fortress/msfol/Signature.scala
+++ b/core/src/main/scala/fortress/msfol/Signature.scala
@@ -301,9 +301,11 @@ case class Signature private (
     def hasFuncDeclWithName(name: String): Boolean = functionDeclarations.exists(_.name == name)
 
     def hasFuncDefWithName(name: String): Boolean = functionDefinitions.exists(_.name == name)
+
+    def hasFuncWithName(name: String): Boolean = hasFuncDeclWithName(name) || hasFuncDefWithName(name)
     
     def functionWithName(name: String): Option[FuncDecl] = functionDeclarations.find(_.name == name)
-    
+
     // Includes an unapply function
     def replaceIntegersWithBitVectors(bitwidth: Int): (Signature, Interpretation => Interpretation) = {
         def replaceSort(s: Sort): Sort = s match {

--- a/core/src/main/scala/fortress/operations/ClosureEliminatorClaessen.scala
+++ b/core/src/main/scala/fortress/operations/ClosureEliminatorClaessen.scala
@@ -80,8 +80,8 @@ class ClosureEliminatorClaessen(topLevelTerm: Term, signature: Signature, scopes
 
         def visitReflexiveClosure(rc: ReflexiveClosure): Term = {
             val reflexiveClosureName = getReflexiveClosureName(rc.functionName)
-            val rel = signature.queryFunctionDeclaration(rc.functionName).get
-            val sort = rel.argSorts(0)
+            // Find the sort we are closing over
+            val sort = getClosingSortOfFunction(rc.functionName)
             if (!queryFunction(reflexiveClosureName)){
                 defineReflexiveClosure(sort, rc.functionName)
             }
@@ -92,8 +92,8 @@ class ClosureEliminatorClaessen(topLevelTerm: Term, signature: Signature, scopes
         def visitClosure(c: Closure): Term = {
             val closureName = getClosureName(c.functionName)
             val reflexiveClosureName = getReflexiveClosureName(c.functionName)
-            val rel = signature.queryFunctionDeclaration(c.functionName).get
-            val sort = rel.argSorts(0)
+            // Find the sort we are closing over
+            val sort = getClosingSortOfFunction(c.functionName)
 
             if (!queryFunction(closureName)){
                 if (!queryFunction(reflexiveClosureName)){

--- a/core/src/main/scala/fortress/operations/ClosureEliminatorEijck.scala
+++ b/core/src/main/scala/fortress/operations/ClosureEliminatorEijck.scala
@@ -130,8 +130,8 @@ class ClosureEliminatorEijck(topLevelTerm: Term, signature: Signature, scopes: M
             // Skip if we already did it
             if (!queryFunction(closureName)){
                 // use index to find sort
-                val rel = signature.queryFunctionDeclaration(functionName).get
-                val sort = rel.argSorts(0)
+                // Find the sort we are closing over
+                val sort = getClosingSortOfFunction(functionName)
 
                 val fixedSorts = getFixedSorts(functionName)
                 val fixedVars = getFixedVars(fixedSorts.length)
@@ -197,9 +197,8 @@ class ClosureEliminatorEijck(topLevelTerm: Term, signature: Signature, scopes: M
             // Skip if we already did it
             if (!queryFunction(reflexiveClosureName)){
                 // use index to find sort
-                val rel = signature.queryFunctionDeclaration(functionName).get
-                var argSorts = new ArrayList(rel.argSorts.asJava)
-                val sort = rel.argSorts(0)
+                // Find the sort we are closing over
+                val sort = getClosingSortOfFunction(functionName)
 
                 val fixedSorts = getFixedSorts(functionName)
                 val fixedVars = getFixedVars(fixedSorts.length)

--- a/core/src/main/scala/fortress/operations/ClosureEliminatorIterative.scala
+++ b/core/src/main/scala/fortress/operations/ClosureEliminatorIterative.scala
@@ -35,8 +35,8 @@ class ClosureEliminatorIterative(topLevelTerm: Term, signature: Signature, scope
             // If we have not generated the function yet
             if (!queryFunction(closureName)) {
                 // Look at original function to make declaration for the closure function
-                val rel = signature.queryFunctionDeclaration(functionName).get
-                val sort = rel.argSorts(0)
+                // Find the sort we are closing over
+                val sort = getClosingSortOfFunction(functionName)
 
                 val fixedSorts = getFixedSorts(functionName)
                 val fixedVars = getFixedVars(fixedSorts.length)
@@ -111,8 +111,8 @@ class ClosureEliminatorIterative(topLevelTerm: Term, signature: Signature, scope
                 val fixedVars = getFixedVars(fixedSorts.length)
                 val fixedArgVars = fixedVars.zip(fixedSorts) map (pair => (pair._1.of(pair._2)))
                 
-                val rel = signature.queryFunctionDeclaration(functionName).get
-                val sort = rel.argSorts(0)
+                // Find the sort we are closing over
+                val sort = getClosingSortOfFunction(functionName)
                 closureFunctions += FuncDecl(reflexiveClosureName, Seq(sort, sort) ++ fixedSorts, Sort.Bool)
                 val x = Var(nameGen.freshName("x"))
                 val y = Var(nameGen.freshName("y"))

--- a/core/src/main/scala/fortress/operations/ClosureEliminatorLiu.scala
+++ b/core/src/main/scala/fortress/operations/ClosureEliminatorLiu.scala
@@ -75,8 +75,8 @@ class ClosureEliminatorLiu(topLevelTerm: Term, signature: Signature, scopes: Map
 
             if (!queryFunction(reflexiveClosureName)){
                 // Build the closure
-                val rel = signature.queryFunctionDeclaration(functionName).get
-                val sort = rel.argSorts(0)
+                // Find the sort we are closing over
+                val sort = getClosingSortOfFunction(functionName)
 
                 val p = nameAuxFunction(closureName)
                 if(!queryFunction(p)){
@@ -116,9 +116,8 @@ class ClosureEliminatorLiu(topLevelTerm: Term, signature: Signature, scopes: Map
 
             if (!queryFunction(closureName)){
                 // Build the closure
-                val rel = signature.queryFunctionDeclaration(functionName).get
-                var argSorts = new ArrayList(rel.argSorts.asJava)
-                val sort = rel.argSorts(0)
+                // Find the sort we are closing over
+                val sort = getClosingSortOfFunction(functionName)
 
                 val p = nameAuxFunction(closureName)
                 if(!queryFunction(p)){

--- a/core/src/main/scala/fortress/operations/ClosureEliminatorSquare.scala
+++ b/core/src/main/scala/fortress/operations/ClosureEliminatorSquare.scala
@@ -28,8 +28,8 @@ class ClosureEliminatorSquare(topLevelTerm: Term, signature: Signature, scopes: 
         // TODO support more arguments
 
         def expandClosure(functionName: String): Unit = {
-            val rel = signature.functionWithName(functionName).get
-            val sort: Sort = rel.argSorts(0)
+            // Find the sort we are closing over
+            val sort = getClosingSortOfFunction(functionName)
 
             val closureName = getClosureName(functionName)
 
@@ -117,8 +117,8 @@ class ClosureEliminatorSquare(topLevelTerm: Term, signature: Signature, scopes: 
                 if (!queryFunction(closureName)) {
                     expandClosure(functionName)
                 }
-                val rel = signature.functionWithName(functionName).get
-                val sort = rel.argSorts(0)
+                // Find the sort we are closing over
+                val sort = getClosingSortOfFunction(functionName)
 
                 val fixedSorts = getFixedSorts(functionName)
                 val fixedVars = getFixedVars(fixedSorts.length)

--- a/core/src/main/scala/fortress/operations/ClosureEliminatorVakili.scala
+++ b/core/src/main/scala/fortress/operations/ClosureEliminatorVakili.scala
@@ -21,8 +21,8 @@ class ClosureEliminatorVakili(topLevelTerm: Term, allowedRelations: Set[String],
 
         def createClosure(functionName: String): Unit = {
             // get the sort we close over
-            val rel = signature.queryFunctionDeclaration(functionName).get
-            val sort = rel.argSorts(0)
+            // Find the sort we are closing over
+            val sort = getClosingSortOfFunction(functionName)
             
             val closureName = getClosureName(functionName)
             val fixedSorts = getFixedSorts(functionName)

--- a/core/src/main/scala/fortress/transformers/ClosureEliminationTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/ClosureEliminationTransformer.scala
@@ -21,6 +21,7 @@ trait ClosureEliminationTransformer extends ProblemStateTransformer {
         val scopes = problemState.scopes
         val forbiddenNames = scala.collection.mutable.Set[String]()
         
+        // Collect names we cannot use when making new declarations
         for(sort <- theory.sorts) {
             forbiddenNames += sort.name
         }
@@ -28,9 +29,17 @@ trait ClosureEliminationTransformer extends ProblemStateTransformer {
         for(fdecl <- theory.functionDeclarations) {
             forbiddenNames += fdecl.name
         }
+
+        for (fdef <- theory.functionDefinitions) {
+            forbiddenNames += fdef.name
+        }
         
         for(constant <- theory.constantDeclarations) {
             forbiddenNames += constant.name
+        }
+
+        for (cdef <- theory.constantDefinitions) {
+            forbiddenNames += cdef.name
         }
         
         val nameGenerator = new IntSuffixNameGenerator(forbiddenNames.toSet, 0)


### PR DESCRIPTION
- Typechecking now considers definitions as well as declarations when querying the function being closed over
- Closure elimination transformers lookup sorts from definitions and declarations
- Added an additional test