### PR TITLE
Fixed which closure elimination transformers had scope as a precondition

### DIFF
--- a/core/src/main/scala/fortress/operations/Closures/ClosureEliminatorEijck.scala
+++ b/core/src/main/scala/fortress/operations/Closures/ClosureEliminatorEijck.scala
@@ -42,8 +42,6 @@ class ClosureEliminatorEijck(topLevelTerm: Term, signature: Signature, scopes: M
         /** Axioms to define a midpoint being closer to the starting node than the ending node along a path for the given relation */
         def addClosenessAxioms(sort: Sort, functionName: String): String = {
 
-            Errors.Internal.precondition(scopes.contains(sort), "sort in closure must be bounded")
-
             // How to actually ensure this does not exist from something else?
             val closenessName: String = "^Close^" + functionName;
             // If we already made this, then we can just leave.

--- a/core/src/main/scala/fortress/operations/Closures/ClosureEliminatorIterative.scala
+++ b/core/src/main/scala/fortress/operations/Closures/ClosureEliminatorIterative.scala
@@ -37,6 +37,7 @@ class ClosureEliminatorIterative(topLevelTerm: Term, signature: Signature, scope
                 // Look at original function to make declaration for the closure function
                 // Find the sort we are closing over
                 val sort = getClosingSortOfFunction(functionName)
+                Errors.Internal.precondition(scopes.contains(sort), "sort in closure must be bounded when using iterative eliminator.")
                 // Record the sort as no longer being able change scope
                 unchangingSorts += sort
 

--- a/core/src/main/scala/fortress/operations/Closures/ClosureEliminatorSquare.scala
+++ b/core/src/main/scala/fortress/operations/Closures/ClosureEliminatorSquare.scala
@@ -30,6 +30,7 @@ class ClosureEliminatorSquare(topLevelTerm: Term, signature: Signature, scopes: 
         def expandClosure(functionName: String): Unit = {
             // Find the sort we are closing over
             val sort = getClosingSortOfFunction(functionName)
+            Errors.Internal.precondition(scopes.contains(sort), "sort in closure must be bounded when using iterative eliminator.")
             // Record the sort as no longer being able change scope
             unchangingSorts += sort
 


### PR DESCRIPTION
Fixes WatForm/fortress#109

- Removed precondition incorrectly checking for a scope on closing sort in Eijck transformer
- Added sort-exists precondition to iterative and squaring transformers
- Added tests to ensure transformers behave correctly in regards to this issue