### PR TITLE
Fix bug in MaxAlphaRenaming with definition argument names getting out of sync

### DIFF
--- a/core/src/main/scala/fortress/operations/Quantifiers/MaxAlphaRenaming.scala
+++ b/core/src/main/scala/fortress/operations/Quantifiers/MaxAlphaRenaming.scala
@@ -53,8 +53,10 @@ object MaxAlphaRenaming {
             newSig = newSig withConstantDefinition (cDef mapBody renameTerm)
         }
         for (fDef <- theory.signature.functionDefinitions) {
+            // Also rename the arguments to avoid getting out of sync with the body
             newSig = newSig withoutFunctionDefinition fDef
-            newSig = newSig withFunctionDefinition (fDef mapBody renameTerm)
+            newSig = newSig withFunctionDefinition FunctionDefinition(
+                fDef.name, freshVars(fDef.argSortedVar), fDef.resultSort, renameTerm(fDef.body))
         }
 
         val newAxioms = theory.axioms map renameTerm


### PR DESCRIPTION
This was the only bug revealed during the correctness run on 2024-08-01. We were alpha-renaming variables in function definitions but not the definition parameters themselves, which sometimes caused problems.