### PR TITLE
Some small performance improvements

### DIFF
--- a/core/src/main/scala/fortress/operations/Simplification/Simplification.scala
+++ b/core/src/main/scala/fortress/operations/Simplification/Simplification.scala
@@ -14,10 +14,13 @@ object Simplifier {
             case Distinct(args) => simplifyStep(Distinct(args.map(simplifyFull)))
             case Exists(vars, body) => simplifyStep(Exists(vars, simplifyFull(body)))
             case Forall(vars, body) => simplifyStep(Forall(vars, simplifyFull(body)))
-            // We consider applications, equals and closures to be atomic and have non-Boolean arguments
-            // so we need not recurse on their arguments
-            case Eq(_, _) | App(_, _) | BuiltinApp(_, _) | Closure(_, _, _, _)
-                 | ReflexiveClosure(_, _, _, _) => simplifyStep(term)
+            case Eq(left, right) => simplifyStep(Eq(simplifyFull(left), simplifyFull(right)))
+            case App(name, args) => simplifyStep(App(name, args.map(simplifyFull)))
+            case BuiltinApp(op, args) => simplifyStep(BuiltinApp(op, args.map(simplifyFull)))
+            case Closure(name, arg1, arg2, fixedArgs) =>
+                simplifyStep(Closure(name, simplifyFull(arg1), simplifyFull(arg2), fixedArgs.map(simplifyFull)))
+            case ReflexiveClosure(name, arg1, arg2, fixedArgs) =>
+                simplifyStep(ReflexiveClosure(name, simplifyFull(arg1), simplifyFull(arg2), fixedArgs.map(simplifyFull)))
             case Top | Bottom | Var(_) | EnumValue(_) | DomainElement(_, _)
                  | IntegerLiteral(_) | BitVectorLiteral(_, _) => term
             case IfThenElse(condition, ifTrue, ifFalse) => simplifyStep(

--- a/core/src/test/scala/operations/SimplificationTest.scala
+++ b/core/src/test/scala/operations/SimplificationTest.scala
@@ -42,15 +42,15 @@ class SimplificationTest extends UnitSuite {
         t3.simplify should be(Bottom)
     }
 
-    test("applications, equals and closures are atomic") {
+    test("applications, equals and closures are not atomic") {
         val t1 = (App("f", y) ==> Top) === Top
         val t2 = App("f", OrList(Top, Bottom))
         val t3 = Term.mkClosure("R", Bottom <==> Top, IfThenElse(Bottom, Top, App("f", x)))
 
 
-        t1.simplify should be((App("f", y) ==> Top) === Top)
-        t2.simplify should be(App("f", OrList(Top, Bottom)))
-        t3.simplify should be(Term.mkClosure("R", Bottom <==> Top, IfThenElse(Bottom, Top, App("f", x))))
+        t1.simplify should be(Top)
+        t2.simplify should be(App("f", Top))
+        t3.simplify should be(Term.mkClosure("R", Bottom, App("f", x)))
     }
 
     test("equal simplification") {


### PR DESCRIPTION
- Simplifier wouldn't recurse through eq/app/closure because they should be atomic; however, if one side of an equality (for example) is an ITE, there could be major simplifications. So recurse through there.
- Fix a condition in OPFI where encountering ITEs would cause the term size to blow up with lots of unnecessary guards, which occurred when dealing with the ordering module. Now a guard is not generated if there are no integers involved.