### PR TITLE
Skip the solver on trivial models

### DIFF
--- a/core/src/main/scala/fortress/compilers/BaseCompiler.scala
+++ b/core/src/main/scala/fortress/compilers/BaseCompiler.scala
@@ -20,6 +20,7 @@ abstract class BaseCompiler extends Compiler {
         timeout: Milliseconds,
         loggers: Seq[EventLogger],
         verbose: Boolean,
+        forceFullCompile: Boolean,
     ): Either[CompilerError, CompilerResult] = {
         class Result(finalProblemState: ProblemState) extends CompilerResult {
             override val theory: Theory = finalProblemState.theory
@@ -60,7 +61,8 @@ abstract class BaseCompiler extends Compiler {
 
                 loggers.foreach(_.transformerFinished(transformer, elapsedNano))
 
-                if (finalPState.flags.trivialResult.isDefined) return Right(new Result(finalPState))
+                if (!forceFullCompile && finalPState.flags.trivialResult.isDefined)
+                    return Right(new Result(finalPState))
 
                 finalPState
             })

--- a/core/src/main/scala/fortress/compilers/BaseCompiler.scala
+++ b/core/src/main/scala/fortress/compilers/BaseCompiler.scala
@@ -1,7 +1,6 @@
 package fortress.compilers
 
 import fortress.msfol._
-import fortress.transformers._
 import fortress.util._
 import fortress.interpretation._
 import fortress.logging._
@@ -9,8 +8,6 @@ import fortress.operations.TermOps._
 import fortress.problemstate._
 import fortress.util.Control.measureTime
 import fortress.util.Control.withCountdown
-import fortress.util.Extensions._
-
 
 
 // these are definitions that are common for all compilers
@@ -24,31 +21,10 @@ abstract class BaseCompiler extends Compiler {
         loggers: Seq[EventLogger],
         verbose: Boolean,
     ): Either[CompilerError, CompilerResult] = {
-
-        //println("in base compiler compile")
-        val initialProblemState = ProblemState(theory, scopes, verbose)
-
-        val finalProblemState = withCountdown(timeout) { countdown => {
-            transformerSequence.foldLeft(initialProblemState)((pState, transformer) => {
-                if(countdown.isExpired) return Left(CompilerError.Timeout)
-                loggers.foreach(_.transformerStarted(transformer))
-
-                val (finalPState, elapsedNano) = measureTime {
-                    transformer(pState)
-                }
-
-                loggers.foreach(_.transformerFinished(transformer, elapsedNano))
-
-                finalPState
-            })
-        }}
-
-//        println(s"Final theory:\n-----")
-//        println(Dump.theoryToSmtlibTC(finalProblemState.theory))
-//        println("-----")
-
-        object Result extends CompilerResult {
+        class Result(finalProblemState: ProblemState) extends CompilerResult {
             override val theory: Theory = finalProblemState.theory
+
+            override val trivialResult: Option[TrivialResult] = finalProblemState.flags.trivialResult
 
             override def decompileInterpretation(interpretation: Interpretation): Interpretation = {
                 finalProblemState.unapplyInterp.foldLeft(interpretation) {
@@ -69,7 +45,32 @@ abstract class BaseCompiler extends Compiler {
                 }
             }
         }
-        Right(Result)
+
+        //println("in base compiler compile")
+        val initialProblemState = ProblemState(theory, scopes, verbose)
+
+        val finalProblemState = withCountdown(timeout) { countdown => {
+            transformerSequence.foldLeft(initialProblemState)((pState, transformer) => {
+                if(countdown.isExpired) return Left(CompilerError.Timeout)
+                loggers.foreach(_.transformerStarted(transformer))
+
+                val (finalPState, elapsedNano) = measureTime {
+                    transformer(pState)
+                }
+
+                loggers.foreach(_.transformerFinished(transformer, elapsedNano))
+
+                if (finalPState.flags.trivialResult.isDefined) return Right(new Result(finalPState))
+
+                finalPState
+            })
+        }}
+
+//        println(s"Final theory:\n-----")
+//        println(Dump.theoryToSmtlibTC(finalProblemState.theory))
+//        println("-----")
+
+        Right(new Result(finalProblemState))
     }
 
 }

--- a/core/src/main/scala/fortress/compilers/Compiler.scala
+++ b/core/src/main/scala/fortress/compilers/Compiler.scala
@@ -25,6 +25,9 @@ abstract class Compiler {
         timeout: Milliseconds,
         loggers: Seq[EventLogger],
         verbose: Boolean,
+        // Use this to force the compiler not to return early in the case of a trivial model.
+        // Instead, the compiler will always generate a model that can be passed to a solver.
+        forceFullCompile: Boolean = false,
     ): Either[CompilerError, CompilerResult]
 
    // do not overwrite in a subclass

--- a/core/src/main/scala/fortress/compilers/CompilerResult.scala
+++ b/core/src/main/scala/fortress/compilers/CompilerResult.scala
@@ -2,12 +2,17 @@ package fortress.compilers
 
 import fortress.msfol.{Declaration, Term, Theory}
 import fortress.interpretation.Interpretation
+import fortress.problemstate.TrivialResult
 
 /** Result from a compiler. */
 trait CompilerResult {
 
     /** The output theory from the compilation process. */
     val theory: Theory
+
+    /** Set if the compilation process determines that the theory is trivially sat or unsat. */
+    val trivialResult: Option[TrivialResult]
+    def isTrivial: Boolean = trivialResult.isDefined
 
     /**
       * A function which undoes the transformations in the compilation process for an interpretation.

--- a/core/src/main/scala/fortress/modelfinders/ModelFinder.scala
+++ b/core/src/main/scala/fortress/modelfinders/ModelFinder.scala
@@ -49,8 +49,8 @@ abstract class ModelFinder extends AutoCloseable {
    def addLogger(logger: EventLogger): Unit
 
    // operations
-   def compile(verbose: Boolean = false): Either[CompilerError, CompilerResult]
-   def checkSat(verbose: Boolean = false): ModelFinderResult
+   def compile(verbose: Boolean = false, forceFullCompile: Boolean = false): Either[CompilerError, CompilerResult]
+   def checkSat(verbose: Boolean = false, alwaysSolve: Boolean = false): ModelFinderResult
    def viewModel(): Interpretation
    def nextInterpretation(): ModelFinderResult
    def countValidModels(): Int

--- a/core/src/main/scala/fortress/modelfinders/ModelFinderResult.scala
+++ b/core/src/main/scala/fortress/modelfinders/ModelFinderResult.scala
@@ -1,9 +1,5 @@
 package fortress.modelfinders
 
-import fortress.problemstate.{TrivialResult, TrivialSat, TrivialUnsat}
-
-import scala.language.implicitConversions
-
 /** The various return possibilities of the model finder.
   * SAT means the theory is satisfiable.
   * UNSAT means the theory is unsatisfiable.
@@ -35,9 +31,4 @@ object ModelFinderResult {
     val Unsat: ModelFinderResult = UnsatResult
     val Unknown: ModelFinderResult = UnknownResult
     val Timeout: ModelFinderResult = TimeoutResult
-
-    implicit def fromTrivialResult(trivialResult: TrivialResult): ModelFinderResult = trivialResult match {
-        case TrivialSat => Sat
-        case TrivialUnsat => Unsat
-    }
 }

--- a/core/src/main/scala/fortress/modelfinders/ModelFinderResult.scala
+++ b/core/src/main/scala/fortress/modelfinders/ModelFinderResult.scala
@@ -1,5 +1,9 @@
 package fortress.modelfinders
 
+import fortress.problemstate.{TrivialResult, TrivialSat, TrivialUnsat}
+
+import scala.language.implicitConversions
+
 /** The various return possibilities of the model finder.
   * SAT means the theory is satisfiable.
   * UNSAT means the theory is unsatisfiable.
@@ -31,4 +35,9 @@ object ModelFinderResult {
     val Unsat: ModelFinderResult = UnsatResult
     val Unknown: ModelFinderResult = UnknownResult
     val Timeout: ModelFinderResult = TimeoutResult
+
+    implicit def fromTrivialResult(trivialResult: TrivialResult): ModelFinderResult = trivialResult match {
+        case TrivialSat => Sat
+        case TrivialUnsat => Unsat
+    }
 }

--- a/core/src/main/scala/fortress/modelfinders/StandardModelFinder.scala
+++ b/core/src/main/scala/fortress/modelfinders/StandardModelFinder.scala
@@ -145,23 +145,23 @@ class StandardModelFinder extends ModelFinder {
     protected def notifyLoggers(notifyFn: EventLogger => Unit): Unit = 
         for(logger <- eventLoggers) notifyFn(logger)
 
-    def compile(verbose: Boolean = false): Either[CompilerError, CompilerResult] = {
+    def compile(verbose: Boolean = false, forceFull: Boolean = false): Either[CompilerError, CompilerResult] = {
         if (!theorySet) 
             Errors.Internal.impossibleState("Called model finder compile or checkSat with no set theory")
         if (!haveCompiled) {
             haveCompiled = true 
             // can only interpret compiler result (timeout/error, during solving or in CLI)
-            compilerResult = compiler.compile(theory, analysisScopes, timeoutMilliseconds, eventLoggers.toList, verbose)           
+            compilerResult = compiler.compile(theory, analysisScopes, timeoutMilliseconds, eventLoggers.toList, verbose, forceFull)
         } 
         compilerResult
     }
 
     /** Check for a satisfying interpretation to the theory with the given scopes. */
-    def checkSat(verbose: Boolean = false): ModelFinderResult = {
+    def checkSat(verbose: Boolean = false, alwaysSolve: Boolean = false): ModelFinderResult = {
         // Restart the timer
         totalTimer.startFresh()
 
-        this.compile(verbose) match {
+        this.compile(verbose, alwaysSolve) match {
             case Left(CompilerError.Timeout) => TimeoutResult
             case Left(CompilerError.Other(errMsg)) => ErrorResult(errMsg)
             case Right(compilerRes) =>
@@ -171,7 +171,7 @@ class StandardModelFinder extends ModelFinder {
 
                 notifyLoggers(_.allTransformersFinished(finalTheory, totalTimer.elapsedNano))
 
-                if (compilerRes.isTrivial) {
+                if (compilerRes.isTrivial && !alwaysSolve) {
                     trivialSolverPhase(compilerRes.trivialResult.get, finalTheory)
                 } else {
                     solverPhase(finalTheory)
@@ -241,9 +241,10 @@ class StandardModelFinder extends ModelFinder {
 
         // have to have solved first, although if this is called directly, then
         // user would never see first interpretation
-        if (!haveSolved) checkSat() 
+        if (!haveSolved) checkSat(alwaysSolve = true)
         if (!hasSatSolution) Errors.Internal.impossibleState("can only view models if the problem is SAT")
-        // TODO: pass a flag to disable returning early when trivial if we want to use the nextInterpretation feature
+        // We can only get the next interpretation if we have gone to the solver
+        // This is why we pass alwaysSolve above
         if (trivialSolution.isDefined) Errors.Internal.preconditionFailed("Can only get the next interpretation if not trivial")
 
         // Negate the current interpretation, but leave out the skolem functions
@@ -296,7 +297,7 @@ class StandardModelFinder extends ModelFinder {
 //        Errors.Internal.precondition(theory.signature.sorts.size == analysisScopes.size,
 //            "Sorry, we can't count valid models for a theory with unbounded sorts")
         
-        checkSat() match {
+        checkSat(alwaysSolve = true) match {
             case SatResult =>
             case UnsatResult => return 0
             case UnknownResult => Errors.Internal.solverError("Solver gave unknown result")

--- a/core/src/main/scala/fortress/modelfinders/StandardModelFinder.scala
+++ b/core/src/main/scala/fortress/modelfinders/StandardModelFinder.scala
@@ -181,11 +181,14 @@ class StandardModelFinder extends ModelFinder {
 
     private def trivialSolverPhase(trivialResult: TrivialResult, finalTheory: Theory): ModelFinderResult = {
         haveSolved = true
-        if (trivialResult == TrivialResult.Sat) {
+        if (trivialResult == TrivialResult.Valid) {
             hasSatSolution = true
             trivialSolution = Some(finalTheory.signature.trivialInterpretation(analysisScopes))
         }
-        val finalResult: ModelFinderResult = trivialResult
+        val finalResult = trivialResult match {
+            case TrivialValid => SatResult
+            case TrivialUnsat => UnsatResult
+        }
         notifyLoggers(_.finished(finalResult, totalTimer.elapsedNano()))
         finalResult
     }

--- a/core/src/main/scala/fortress/operations/TheoryOps.scala
+++ b/core/src/main/scala/fortress/operations/TheoryOps.scala
@@ -98,7 +98,7 @@ case class TheoryOps private(theory: Theory) {
     // Returns a TrivialResult if this theory is trivial according to its axioms
     def checkTrivial: Option[TrivialResult] =
         if (theory.axioms contains Bottom) Some(TrivialResult.Unsat)
-        else if (theory.axioms forall (_ == Top)) Some(TrivialResult.Sat)
+        else if (theory.axioms forall (_ == Top)) Some(TrivialResult.Valid)
         else None
 
     // Returns whether sort inference found any new sorts

--- a/core/src/main/scala/fortress/operations/TheoryOps.scala
+++ b/core/src/main/scala/fortress/operations/TheoryOps.scala
@@ -95,6 +95,12 @@ case class TheoryOps private(theory: Theory) {
         inferSortsCount > 0
     }
 
+    // Returns a TrivialResult if this theory is trivial according to its axioms
+    def checkTrivial: Option[TrivialResult] =
+        if (theory.axioms contains Bottom) Some(TrivialResult.Unsat)
+        else if (theory.axioms forall (_ == Top)) Some(TrivialResult.Sat)
+        else None
+
     // Returns whether sort inference found any new sorts
     def mostUsedDeclarations: Map[Declaration, Int] = {
         val helper = (r: mutable.Map[Declaration, Int], i: Declaration) => r + (i -> 0)

--- a/core/src/main/scala/fortress/problemstate/Flags.scala
+++ b/core/src/main/scala/fortress/problemstate/Flags.scala
@@ -1,9 +1,5 @@
 package fortress.problemstate
 
-import fortress.interpretation.Interpretation
-import fortress.msfol._
-import fortress.util.Errors
-
 /**
   * Contains flags for a problem state
   *
@@ -19,20 +15,23 @@ case class Flags (
     haveRunSkolemizer: Boolean = false,
 
     haveRunMaxAlphaRenaming: Boolean = false,
-    
+
     verbose: Boolean = false,
-    
+
     // typechecker turns these on if these exist in the axioms/defns
     // but transformers (IfLifting, Skolemize) cannot turn them off
     // because all Ites or quantifiers may not have been eliminated
-    
+
     // the typechecker or problemstate constructor sets these flags
     // however transformers can introduce these after typechecking, creation
     // so we should perhaps drop these flags
     // we can't use them to decide whether to run certain transformers or no
-    containsItes: Boolean = false,  
+    containsItes: Boolean = false,
     containsExists: Boolean = false,
     containsNonExactScopes: Boolean = false,
+
+    // This should be set if a transformer determines that the model is trivial.
+    trivialResult: Option[TrivialResult] = None,
 ) {}
 
 // Flags.default is the same as doing Flags() or new Flags()

--- a/core/src/main/scala/fortress/problemstate/TrivialResult.scala
+++ b/core/src/main/scala/fortress/problemstate/TrivialResult.scala
@@ -1,0 +1,11 @@
+package fortress.problemstate
+
+sealed trait TrivialResult
+
+case object TrivialSat extends TrivialResult
+case object TrivialUnsat extends TrivialResult
+
+object TrivialResult {
+    val Sat: TrivialResult = TrivialSat
+    val Unsat: TrivialResult = TrivialUnsat
+}

--- a/core/src/main/scala/fortress/problemstate/TrivialResult.scala
+++ b/core/src/main/scala/fortress/problemstate/TrivialResult.scala
@@ -2,10 +2,13 @@ package fortress.problemstate
 
 sealed trait TrivialResult
 
-case object TrivialSat extends TrivialResult
+// Represents that the problem is trivially valid.
+case object TrivialValid extends TrivialResult
+
+// Represents that the problem is trivially unsatisfiable.
 case object TrivialUnsat extends TrivialResult
 
 object TrivialResult {
-    val Sat: TrivialResult = TrivialSat
+    val Valid: TrivialResult = TrivialValid
     val Unsat: TrivialResult = TrivialUnsat
 }

--- a/core/src/main/scala/fortress/transformers/EvaluateTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/EvaluateTransformer.scala
@@ -1,6 +1,7 @@
 package fortress.transformers
 
 import fortress.operations.EvaluationInliner
+import fortress.operations.TheoryOps._
 import fortress.problemstate.ProblemState
 
 /**
@@ -24,7 +25,11 @@ object EvaluateTransformer extends ProblemStateTransformer {
             inliner.changeTheory(theory)
         }
         val newAxioms = theory.axioms.map(inliner.naturalRecur)
-        problemState.copy(theory = theory.copy(axioms = newAxioms))
+        val newTheory = theory.copy(axioms = newAxioms)
+        problemState.copy(
+            theory = newTheory,
+            flags = problemState.flags.copy(trivialResult = newTheory.checkTrivial),
+        )
     }
 
 }

--- a/core/src/main/scala/fortress/transformers/Simplify/SimplifyTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Simplify/SimplifyTransformer.scala
@@ -1,6 +1,5 @@
 package fortress.transformers
 
-import fortress.msfol._
 import fortress.operations.TermOps._
 import fortress.operations.TheoryOps._
 import fortress.problemstate.ProblemState
@@ -10,7 +9,11 @@ import fortress.problemstate.ProblemState
 object SimplifyTransformer extends ProblemStateTransformer {
 
     override def apply(problemState: ProblemState): ProblemState =  {
-      problemState.copy(theory = problemState.theory.mapAllTerms(_.simplify))
+        val newTheory = problemState.theory.mapAllTerms(_.simplify)
+        problemState.copy(
+            theory = newTheory,
+            flags = problemState.flags.copy(trivialResult = newTheory.checkTrivial),
+        )
     }
 
 


### PR DESCRIPTION
A transformer can now optionally set a `trivialResult` on the ProblemState flags. This is recognized by `BaseCompiler`, which returns early and does not run the rest of the transformers, and `StandardModelFinder`, which does not call the solver. `EvaluateTransformer` and `SimplifyTransformer` set the flag to indicate UNSAT if any of the theory's axioms are `false` and SAT if all of the theory's axioms are `true`.