### PR TITLE
Implement evaluation for integers and bitvectors

### DIFF
--- a/core/src/main/scala/fortress/operations/DefinitionJit.scala
+++ b/core/src/main/scala/fortress/operations/DefinitionJit.scala
@@ -103,6 +103,136 @@ class DefinitionJit(theory: Theory) {
                 case Bottom => jitIfFalse(args)
             }
 
+        // Evaluate integers
+        case i @ IntegerLiteral(_) => _ => Some(i)
+        case BuiltinApp(IntNeg, Seq(x)) =>
+            val jitX = compileTerm(x, varIdxs)
+            args => jitX(args) map {
+                case IntegerLiteral(i) => IntegerLiteral(-i)
+            }
+        case BuiltinApp(IntPlus, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (IntegerLiteral(i), IntegerLiteral(j)) => IntegerLiteral(i + j)
+            }
+        case BuiltinApp(IntSub, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (IntegerLiteral(i), IntegerLiteral(j)) => IntegerLiteral(i - j)
+            }
+        case BuiltinApp(IntMult, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (IntegerLiteral(i), IntegerLiteral(j)) => IntegerLiteral(i * j)
+            }
+        case BuiltinApp(IntDiv, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) flatMap {
+                case (IntegerLiteral(_), IntegerLiteral(0)) => None // do not evaluate div-by-zero
+                case (IntegerLiteral(i), IntegerLiteral(j)) => Some(IntegerLiteral(i / j))
+            }
+        case BuiltinApp(IntMod, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) flatMap {
+                case (IntegerLiteral(_), IntegerLiteral(0)) => None // do not evaluate mod-by-zero
+                case (IntegerLiteral(i), IntegerLiteral(j)) => Some(IntegerLiteral(i % j))
+            }
+        case BuiltinApp(IntLE, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (IntegerLiteral(i), IntegerLiteral(j)) => fromBool(i <= j)
+            }
+        case BuiltinApp(IntLT, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (IntegerLiteral(i), IntegerLiteral(j)) => fromBool(i < j)
+            }
+        case BuiltinApp(IntGE, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (IntegerLiteral(i), IntegerLiteral(j)) => fromBool(i >= j)
+            }
+        case BuiltinApp(IntGT, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (IntegerLiteral(i), IntegerLiteral(j)) => fromBool(i > j)
+            }
+
+        // Evaluate BitVectors
+        case bv @ BitVectorLiteral(_, _) => _ => Some(bv)
+        case BuiltinApp(BvNeg, Seq(x)) =>
+            val jitX = compileTerm(x, varIdxs)
+            args => jitX(args) map {
+                case BitVectorLiteral(i, bitwidth) => wrapBv(-i, bitwidth)
+            }
+        case BuiltinApp(BvPlus, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => wrapBv(i + j, bw1)
+            }
+        case BuiltinApp(BvSub, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => wrapBv(i - j, bw1)
+            }
+        case BuiltinApp(BvMult, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => wrapBv(i * j, bw1)
+            }
+        case BuiltinApp(BvSignedDiv, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) flatMap {
+                case (_, BitVectorLiteral(0, _)) => None // don't try and handle div-by-zero here
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => Some(wrapBv(i / j, bw1))
+            }
+        // TODO: What's the difference betweeen BvSignedMod and BvSignedRem?
+        case BuiltinApp(BvSignedMod, _) => _ => None
+        case BuiltinApp(BvSignedRem, _) => _ => None
+        case BuiltinApp(BvSignedLE, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i <= j)
+            }
+        case BuiltinApp(BvSignedLT, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i < j)
+            }
+        case BuiltinApp(BvSignedGE, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i >= j)
+            }
+        case BuiltinApp(BvSignedGT, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i > j)
+            }
+        case BuiltinApp(BvConcat, Seq(x, y)) =>
+            val jitX = compileTerm(x, varIdxs)
+            val jitY = compileTerm(y, varIdxs)
+            args => (jitX(args) zip jitY(args)) map {
+                case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) => BitVectorLiteral((i << bw2) | j, bw1 + bw2)
+            }
+
         // TODO: Evaluate quantifiers by expanding?
         case Forall(_, _) => _ => None
         case Exists(_, _) => _ => None
@@ -110,21 +240,19 @@ class DefinitionJit(theory: Theory) {
         // TODO: Evaluate closures. (Currently, run this after closure elimination).
         case Closure(_, _, _, _) => _ => None
         case ReflexiveClosure(_, _, _, _) => _ => None
-
-        // TODO: Evaluate integers and bitvectors and functions of them!
-        case IntegerLiteral(_) => _ => None
-        case BitVectorLiteral(_, _) => _ => None
-        case BuiltinApp(_, _) => _ => None
     }
 
     private def evalEqIff(left: Term, right: Term, varIdxs: Map[Var, Int]): JitFunc = {
         val jitLeft = compileTerm(left, varIdxs)
         val jitRight = compileTerm(right, varIdxs)
         args => (jitLeft(args) zip jitRight(args)) map {
-            case (evalLeft, evalRight) =>
-                if (evalLeft == evalRight) Top
-                else Bottom
+            case (evalLeft, evalRight) => fromBool(evalLeft == evalRight)
         }
     }
+
+    private def fromBool(bool: Boolean): Value = if (bool) Top else Bottom
+
+    private def wrapBv(value: Int, bitwidth: Int): BitVectorLiteral =
+        BitVectorLiteral(value & ((1 << bitwidth) - 1), bitwidth)
 
 }

--- a/core/src/main/scala/fortress/operations/Evaluator.scala
+++ b/core/src/main/scala/fortress/operations/Evaluator.scala
@@ -154,9 +154,22 @@ class Evaluator(private var theory: Theory) {
             case (_, BitVectorLiteral(0, _)) => None // don't try and handle div-by-zero here
             case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => Some(wrapBv(i / j, bw1))
         }
-        // TODO: What's the difference betweeen BvSignedMod and BvSignedRem?
-        case BuiltinApp(BvSignedMod, _) => None
-        case BuiltinApp(BvSignedRem, _) => None
+        case BuiltinApp(BvSignedMod, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) flatMap {
+            case (_, BitVectorLiteral(0, _)) => None // don't try and handle mod-by-zero here
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 =>
+                // In BvSignedMod, the sign follows the divisor (second argument)
+                // https://z3prover.github.io/api/html/group__capi.html#ga9f99e96fc60cb67789fab87be0ba5919
+                val result = (i.abs % j.abs) * j.sign
+                Some(wrapBv(result, bw1))
+        }
+        case BuiltinApp(BvSignedRem, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) flatMap {
+            case (_, BitVectorLiteral(0, _)) => None // don't try and handle rem-by-zero here
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 =>
+                // In BvSignedRem, the sign follows the dividend (first argument)
+                // https://z3prover.github.io/api/html/group__capi.html#ga9f99e96fc60cb67789fab87be0ba5919
+                val result = (i.abs % j.abs) * i.sign
+                Some(wrapBv(result, bw1))
+        }
         case BuiltinApp(BvSignedLE, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
             case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i <= j)
         }

--- a/core/src/main/scala/fortress/operations/Evaluator.scala
+++ b/core/src/main/scala/fortress/operations/Evaluator.scala
@@ -101,6 +101,78 @@ class Evaluator(private var theory: Theory) {
                 case Bottom => tryCastToValue(ifFalse)
             }
 
+        // Evaluate integers
+        case i @ IntegerLiteral(_) => Some(i)
+        case BuiltinApp(IntNeg, Seq(x)) => tryCastToValue(x) map {
+            case IntegerLiteral(i) => IntegerLiteral(-i)
+        }
+        case BuiltinApp(IntPlus, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (IntegerLiteral(i), IntegerLiteral(j)) => IntegerLiteral(i + j)
+        }
+        case BuiltinApp(IntSub, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (IntegerLiteral(i), IntegerLiteral(j)) => IntegerLiteral(i - j)
+        }
+        case BuiltinApp(IntMult, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (IntegerLiteral(i), IntegerLiteral(j)) => IntegerLiteral(i * j)
+        }
+        case BuiltinApp(IntDiv, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) flatMap {
+            case (_, IntegerLiteral(0)) => None // don't try and handle div-by-zero here
+            case (IntegerLiteral(i), IntegerLiteral(j)) => Some(IntegerLiteral(i / j))
+        }
+        case BuiltinApp(IntMod, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) flatMap {
+            case (_, IntegerLiteral(0)) => None // don't try and handle mod-by-zero here
+            case (IntegerLiteral(i), IntegerLiteral(j)) => Some(IntegerLiteral(i % j))
+        }
+        case BuiltinApp(IntLE, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (IntegerLiteral(i), IntegerLiteral(j)) => fromBool(i <= j)
+        }
+        case BuiltinApp(IntLT, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (IntegerLiteral(i), IntegerLiteral(j)) => fromBool(i < j)
+        }
+        case BuiltinApp(IntGE, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (IntegerLiteral(i), IntegerLiteral(j)) => fromBool(i >= j)
+        }
+        case BuiltinApp(IntGT, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (IntegerLiteral(i), IntegerLiteral(j)) => fromBool(i > j)
+        }
+
+        // Evaluate BitVectors
+        case bv @ BitVectorLiteral(_, _) => Some(bv)
+        case BuiltinApp(BvNeg, Seq(x)) => tryCastToValue(x) map {
+            case BitVectorLiteral(i, bitwidth) => wrapBv(-i, bitwidth)
+        }
+        case BuiltinApp(BvPlus, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => wrapBv(i + j, bw1)
+        }
+        case BuiltinApp(BvSub, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => wrapBv(i - j, bw1)
+        }
+        case BuiltinApp(BvMult, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => wrapBv(i * j, bw1)
+        }
+        case BuiltinApp(BvSignedDiv, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) flatMap {
+            case (_, BitVectorLiteral(0, _)) => None // don't try and handle div-by-zero here
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => Some(wrapBv(i / j, bw1))
+        }
+        // TODO: What's the difference betweeen BvSignedMod and BvSignedRem?
+        case BuiltinApp(BvSignedMod, _) => None
+        case BuiltinApp(BvSignedRem, _) => None
+        case BuiltinApp(BvSignedLE, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i <= j)
+        }
+        case BuiltinApp(BvSignedLT, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i < j)
+        }
+        case BuiltinApp(BvSignedGE, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i >= j)
+        }
+        case BuiltinApp(BvSignedGT, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) if bw1 == bw2 => fromBool(i > j)
+        }
+        case BuiltinApp(BvConcat, Seq(x, y)) => (tryCastToValue(x) zip tryCastToValue(y)) map {
+            case (BitVectorLiteral(i, bw1), BitVectorLiteral(j, bw2)) => BitVectorLiteral((i << bw2) | j, bw1 + bw2)
+        }
+
         // TODO: Evaluate quantifiers by expanding?
         case Forall(_, _) => None
         case Exists(_, _) => None
@@ -108,24 +180,21 @@ class Evaluator(private var theory: Theory) {
         // TODO: Evaluate closures. (Currently, run this after closure elimination).
         case Closure(_, _, _, _) => None
         case ReflexiveClosure(_, _, _, _) => None
-
-        // TODO: Evaluate integers and bitvectors and functions of them!
-        case IntegerLiteral(_) => None
-        case BitVectorLiteral(_, _) => None
-        case BuiltinApp(_, _) => None
     }
 
     // Short-circuit: if left is unknown, don't evaluate right
     private def evalEqIff(left: Term, right: Term): Option[Value] = tryCastToValue(left) flatMap { leftValue =>
-        tryCastToValue(right) map { rightValue =>
-            if (leftValue == rightValue) Top
-            else Bottom
-        }
+        tryCastToValue(right) map { rightValue => fromBool(leftValue == rightValue) }
     }
 
     private def tryCastToValue(term: Term): Option[Value] = term match {
         case value: Value => Some(value)
         case _ => None
     }
+
+    private def fromBool(bool: Boolean): Value = if (bool) Top else Bottom
+
+    private def wrapBv(value: Int, bitwidth: Int): BitVectorLiteral =
+        BitVectorLiteral(value & ((1 << bitwidth) - 1), bitwidth)
 
 }

--- a/core/src/main/scala/fortress/operations/TypeChecker.scala
+++ b/core/src/main/scala/fortress/operations/TypeChecker.scala
@@ -260,7 +260,7 @@ class TypeChecker(signature: Signature) extends TermVisitorWithTypeContext[TypeC
         
 
         val resultSort: Sort = signature.queryFunction(funcName, argSorts) match {
-            case None => throw new TypeCheckException.WrongSort(signature.functionWithName(funcName).get.toString + " cannot accept argument sorts " + argSorts.toString + " in " + app.toString)
+            case None => throw new TypeCheckException.WrongSort(funcName + " cannot accept argument sorts " + argSorts.toString + " in " + app.toString)
             case Some(Left(fdecl)) => fdecl.resultSort
             case Some(Right(fdefn)) => fdefn.resultSort
         }


### PR DESCRIPTION
This expands `Evaluator` and `DefinitionJit` to evaluate integers, bitvectors, and builtin functions of the two. `BvSignedRem` and `BvSignedMod` aren't yet implemented since I wasn't sure what the difference between them is.

On `4-bit-adder.als`, the evaluator reduces the time on my machine from ~6s to ~2s!