### PR TITLE
Consistent unapply

### DIFF
--- a/core/src/main/scala/fortress/compilers/BaseCompiler.scala
+++ b/core/src/main/scala/fortress/compilers/BaseCompiler.scala
@@ -28,8 +28,8 @@ abstract class BaseCompiler extends Compiler {
             override val trivialResult: Option[TrivialResult] = finalProblemState.flags.trivialResult
 
             override def decompileInterpretation(interpretation: Interpretation): Interpretation = {
-                finalProblemState.unapplyInterp.foldRight(interpretation) {
-                    (unapplyFn, interp) => unapplyFn(interp)
+                finalProblemState.unapplyInterp.foldLeft(interpretation) {
+                    (interp, unapplyFn) => unapplyFn(interp)
                 }
             }
 

--- a/core/src/main/scala/fortress/msfol/Theory.scala
+++ b/core/src/main/scala/fortress/msfol/Theory.scala
@@ -42,6 +42,10 @@ case class Theory private (signature: Signature, axioms: Set[Term]) {
     def withAxioms(newAxioms: Iterable[Term]): Theory = {
         Theory(signature, axioms ++ newAxioms)
     }
+
+    def replaceAxioms(newAxioms: Set[Term]): Theory = {
+      copy(axioms = newAxioms)
+    }
     
     /** Returns a theory consisting of the current theory but with the given
       * sort declaration added. Note that this does not modify the current Theory object,

--- a/core/src/main/scala/fortress/problemstate/ProblemState.scala
+++ b/core/src/main/scala/fortress/problemstate/ProblemState.scala
@@ -58,7 +58,7 @@ case class ProblemState private (
         
     }
 
-    def withUnapplyInterp(unapp: Interpretation => Interpretation): ProblemState = {
+    def addUnapplyInterp(unapp: Interpretation => Interpretation): ProblemState = {
         copy(unapplyInterp = unapp :: unapplyInterp)
     }
 
@@ -78,10 +78,30 @@ case class ProblemState private (
     }
 
     /**
+      * Unions skolemConstants with `skc`
+      *
+      * @param skc
+      * @return a new `ProblemState`
+      */
+    def addSkolemConstants(skc: Set[AnnotatedVar]): ProblemState = {
+        copy(skolemConstants = skolemConstants union skc)
+    }
+
+    /**
       * Replaces skolem functions with `skf`
       */
     def withSkolemFunctions(skf: Set[FuncDecl]): ProblemState = {
         copy(skolemFunctions = skf)
+    }
+
+    /**
+      * Unions skolemFunctions with `skf`
+      *
+      * @param skf
+      * @return a new `ProblemState`
+      */
+    def addSkolemFunctions(skc: Set[FuncDecl]): ProblemState = {
+        copy(skolemFunctions = skolemFunctions union skc)
     }
 
     /**
@@ -92,6 +112,16 @@ case class ProblemState private (
       */
     def withRangeRestrictions(rangeRestrictions: Set[RangeRestriction]): ProblemState = {
         copy(rangeRestrictions = rangeRestrictions)
+    }
+
+    /**
+      * Adds additional range restrictions to the existing set of range restrictions.
+      *
+      * @param addedRangeRestrictions
+      * @return A new `ProblemState`
+      */
+    def addRangeRestrictions(addedRangeRestrictions: Set[RangeRestriction]): ProblemState = {
+        copy(rangeRestrictions = rangeRestrictions union addedRangeRestrictions)
     }
 }
 

--- a/core/src/main/scala/fortress/problemstate/ProblemState.scala
+++ b/core/src/main/scala/fortress/problemstate/ProblemState.scala
@@ -59,7 +59,7 @@ case class ProblemState private (
     }
 
     def withUnapplyInterp(unapp: Interpretation => Interpretation): ProblemState = {
-        copy(unapplyInterp = unapplyInterp :+ unapp)
+        copy(unapplyInterp = unapp :: unapplyInterp)
     }
 
     def withoutUnapplyInterps(): ProblemState = {
@@ -68,6 +68,30 @@ case class ProblemState private (
 
     def withFlags(fl:Flags):ProblemState = {
         copy(flags = fl)
+    }
+
+    /**
+      * Replaces skolem constants with `sk`
+      */
+    def withSkolemConstants(skc: Set[AnnotatedVar]): ProblemState = {
+        copy(skolemConstants = skc)
+    }
+
+    /**
+      * Replaces skolem functions with `skf`
+      */
+    def withSkolemFunctions(skf: Set[FuncDecl]): ProblemState = {
+        copy(skolemFunctions = skf)
+    }
+
+    /**
+      * Replaces range restrictions with argument.
+      *
+      * @param rangeRestrictions
+      * @return A new `ProblemState`
+      */
+    def withRangeRestrictions(rangeRestrictions: Set[RangeRestriction]): ProblemState = {
+        copy(rangeRestrictions = rangeRestrictions)
     }
 }
 

--- a/core/src/main/scala/fortress/transformers/Closures/ClosureEliminationTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Closures/ClosureEliminationTransformer.scala
@@ -126,7 +126,7 @@ trait ClosureEliminationTransformer extends ProblemStateTransformer {
         
         problemState
         .withTheory(resultTheory)
-        .withUnapplyInterp(unapply)
+        .addUnapplyInterp(unapply)
         .withScopes(newScopes)
     }
     

--- a/core/src/main/scala/fortress/transformers/Closures/ClosureEliminationTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Closures/ClosureEliminationTransformer.scala
@@ -124,11 +124,10 @@ trait ClosureEliminationTransformer extends ProblemStateTransformer {
         }).toMap
         
         
-        problemState.copy(
-            theory=resultTheory,
-            unapplyInterp = problemState.unapplyInterp :+ unapply,
-            scopes = newScopes,
-        )
+        problemState
+        .withTheory(resultTheory)
+        .withUnapplyInterp(unapply)
+        .withScopes(newScopes)
     }
     
     

--- a/core/src/main/scala/fortress/transformers/Closures/ClosureEliminationVakiliTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Closures/ClosureEliminationVakiliTransformer.scala
@@ -108,7 +108,7 @@ object ClosureEliminationVakiliTransformer extends ProblemStateTransformer {
         //ProblemState(resultTheory, scopes, skc, skf, rangeRestricts, unapplyInterp :+ unapply, distinctConstants)
         problemState
         .withTheory(resultTheory)
-        .withUnapplyInterp(unapply)
+        .addUnapplyInterp(unapply)
     }
 
 }

--- a/core/src/main/scala/fortress/transformers/Closures/ClosureEliminationVakiliTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Closures/ClosureEliminationVakiliTransformer.scala
@@ -106,7 +106,9 @@ object ClosureEliminationVakiliTransformer extends ProblemStateTransformer {
         }
         
         //ProblemState(resultTheory, scopes, skc, skf, rangeRestricts, unapplyInterp :+ unapply, distinctConstants)
-        problemState.copy(theory=resultTheory, unapplyInterp = problemState.unapplyInterp :+ unapply)
+        problemState
+        .withTheory(resultTheory)
+        .withUnapplyInterp(unapply)
     }
 
 }

--- a/core/src/main/scala/fortress/transformers/Definitions/AxiomatizeFuncDefnTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Definitions/AxiomatizeFuncDefnTransformer.scala
@@ -33,7 +33,7 @@ object AxiomatizeFuncDefnTransformer extends ProblemStateTransformer {
 
         problemState
         .withTheory(resultTheory)
-        .withUnapplyInterp(unapply)
+        .addUnapplyInterp(unapply)
     }
 
 

--- a/core/src/main/scala/fortress/transformers/Definitions/AxiomatizeFuncDefnTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Definitions/AxiomatizeFuncDefnTransformer.scala
@@ -31,7 +31,9 @@ object AxiomatizeFuncDefnTransformer extends ProblemStateTransformer {
             }
         }
 
-        problemState.copy(theory = resultTheory, unapplyInterp = unapply :: problemState.unapplyInterp)        
+        problemState
+        .withTheory(resultTheory)
+        .withUnapplyInterp(unapply)
     }
 
 

--- a/core/src/main/scala/fortress/transformers/Definitions/EliminateUnusedTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Definitions/EliminateUnusedTransformer.scala
@@ -75,7 +75,7 @@ object EliminateUnusedTransformer extends ProblemStateTransformer {
 
         problemState
         .withTheory(newTheory)
-        .withUnapplyInterp(unapply)
+        .addUnapplyInterp(unapply)
     }
 
 }

--- a/core/src/main/scala/fortress/transformers/Definitions/EliminateUnusedTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Definitions/EliminateUnusedTransformer.scala
@@ -65,14 +65,17 @@ object EliminateUnusedTransformer extends ProblemStateTransformer {
             )
         }
 
-        problemState.copy(theory = problemState.theory.copy(
-            signature = problemState.theory.signature.copy(
+        val newSignature = problemState.theory.signature.copy(
                 functionDeclarations = fDecls,
                 constantDeclarations = cDecls,
                 functionDefinitions = fDefs,
                 constantDefinitions = cDefs,
-            ),
-        )).withUnapplyInterp(unapply)
+            )
+        val newTheory = problemState.theory.copy(signature = newSignature)
+
+        problemState
+        .withTheory(newTheory)
+        .withUnapplyInterp(unapply)
     }
 
 }

--- a/core/src/main/scala/fortress/transformers/EnumsToDEsTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/EnumsToDEsTransformer.scala
@@ -50,11 +50,10 @@ object EnumsToDEsTransformer extends ProblemStateTransformer {
 
         // The problem contain scopes for the enums, which should remain the same
         //ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapply :: unapplyInterp, distinctConstants)
-        problemState.copy(
-            theory = newTheory,
-            unapplyInterp = unapply :: problemState.unapplyInterp,
-            scopes = newScopes
-        )
+        problemState
+        .withTheory(newTheory)
+        .withUnapplyInterp(unapply)
+        .withScopes(newScopes)
     }
     
     def computeEnumSortMapping(theory: Theory): Map[EnumValue, DomainElement] = {

--- a/core/src/main/scala/fortress/transformers/EnumsToDEsTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/EnumsToDEsTransformer.scala
@@ -52,7 +52,7 @@ object EnumsToDEsTransformer extends ProblemStateTransformer {
         //ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapply :: unapplyInterp, distinctConstants)
         problemState
         .withTheory(newTheory)
-        .withUnapplyInterp(unapply)
+        .addUnapplyInterp(unapply)
         .withScopes(newScopes)
     }
     

--- a/core/src/main/scala/fortress/transformers/EvaluateTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/EvaluateTransformer.scala
@@ -26,10 +26,10 @@ object EvaluateTransformer extends ProblemStateTransformer {
         }
         val newAxioms = theory.axioms.map(inliner.naturalRecur)
         val newTheory = theory.copy(axioms = newAxioms)
-        problemState.copy(
-            theory = newTheory,
-            flags = problemState.flags.copy(trivialResult = newTheory.checkTrivial),
-        )
+
+        problemState
+        .withTheory(newTheory)
+        .withFlags(problemState.flags.copy(trivialResult = newTheory.checkTrivial))
     }
 
 }

--- a/core/src/main/scala/fortress/transformers/IfLiftingTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/IfLiftingTransformer.scala
@@ -10,36 +10,26 @@ import fortress.problemstate.ProblemState
 object IfLiftingTransformer extends ProblemStateTransformer {
     override def apply(problemState: ProblemState): ProblemState = {
 
-        //if (problemState.flags.containsItes) {
-            
-            val theory = problemState.theory
+        val theory = problemState.theory
 
-            // axioms are of Boolean type so we can remove all ites from them
-            var newTheory = theory.mapAxioms(t => t.iflift(BoolSort))
-            
-            // iflifting for defns can be done
-            // but may not remove all ites
-            // if the return sort of the defn body is not Boolean
-            for(cDef <- theory.signature.constantDefinitions){
-                newTheory = newTheory.withoutConstantDefinition(cDef)
-                newTheory = newTheory.withConstantDefinition(cDef.mapBody(t => t.iflift(cDef.sort)))
-            }
-            for(fDef <- theory.signature.functionDefinitions){
-                newTheory = newTheory.withoutFunctionDefinition(fDef)
-                newTheory = newTheory.withFunctionDefinition(fDef.mapBody(t => t.iflift(fDef.resultSort)))
-            }
-            
-            return problemState.copy(
-                theory = newTheory,
-                flags = problemState.flags.copy(
-                    haveRunIfLifting = true
-                )
-            )
-        /*
-        } else {
-            return problemState
+        // axioms are of Boolean type so we can remove all ites from them
+        var newTheory = theory.mapAxioms(t => t.iflift(BoolSort))
+        
+        // iflifting for defns can be done
+        // but may not remove all ites
+        // if the return sort of the defn body is not Boolean
+        for(cDef <- theory.signature.constantDefinitions){
+            newTheory = newTheory.withoutConstantDefinition(cDef)
+            newTheory = newTheory.withConstantDefinition(cDef.mapBody(t => t.iflift(cDef.sort)))
         }
-        */
+        for(fDef <- theory.signature.functionDefinitions){
+            newTheory = newTheory.withoutFunctionDefinition(fDef)
+            newTheory = newTheory.withFunctionDefinition(fDef.mapBody(t => t.iflift(fDef.resultSort)))
+        }
+
+        problemState
+        .withTheory(newTheory)
+        .withFlags(problemState.flags.copy(haveRunIfLifting = true))
     }
     
 

--- a/core/src/main/scala/fortress/transformers/Integers/AxiomatizeIntPredDefnsTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Integers/AxiomatizeIntPredDefnsTransformer.scala
@@ -52,9 +52,8 @@ object AxiomatizeIntPredDefnsTransformer extends ProblemStateTransformer {
         .withFunctionDeclarations(newFuncDecls)
         .withAxioms(funcAxioms)
 
-        problemState.copy(
-            theory = newTheory
-        )
+        problemState
+        .withTheory(newTheory)
     }
 
 }

--- a/core/src/main/scala/fortress/transformers/Integers/IntOPFITransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Integers/IntOPFITransformer.scala
@@ -536,7 +536,7 @@ object IntOPFITransformer extends ProblemStateTransformer {
         // could this be done with domain elements? Yes. Should it... probably? TODO
         val newTheory = Theory(newSignature, allNewAxioms)
         problemState.withScopes(newScopes).withTheory(newTheory)
-            .withUnapplyInterp(unapplyInterp)
+            .addUnapplyInterp(unapplyInterp)
     }
 
     // Info passed down through transform

--- a/core/src/main/scala/fortress/transformers/Integers/IntToBVTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Integers/IntToBVTransformer.scala
@@ -35,7 +35,7 @@ object IntToBVTransformer extends ProblemStateTransformer {
             val newScopes: Map[Sort, Scope] = problemState.scopes.filter(x => !(x._1 == IntSort)) + (BitVectorSort(bitwidth) -> ExactScope(totalValues))
             // change the theory
             newProblemState = problemState.withTheory(Theory(newSig, newAxioms)).withScopes(newScopes)
-                .withUnapplyInterp(unapply)
+                .addUnapplyInterp(unapply)
         }
 
         /*

--- a/core/src/main/scala/fortress/transformers/Integers/IntToBVTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Integers/IntToBVTransformer.scala
@@ -34,7 +34,7 @@ object IntToBVTransformer extends ProblemStateTransformer {
             // remove IntSort from the scopes map
             val newScopes: Map[Sort, Scope] = problemState.scopes.filter(x => !(x._1 == IntSort)) + (BitVectorSort(bitwidth) -> ExactScope(totalValues))
             // change the theory
-            newProblemState = problemState.withTheory(Theory.mkTheoryWithSignature(newSig).withAxioms(newAxioms)).withScopes(newScopes)
+            newProblemState = problemState.withTheory(Theory(newSig, newAxioms)).withScopes(newScopes)
                 .withUnapplyInterp(unapply)
         }
 

--- a/core/src/main/scala/fortress/transformers/NnfTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/NnfTransformer.scala
@@ -25,11 +25,10 @@ object NnfTransformer extends ProblemStateTransformer {
             newTheory = newTheory.withoutFunctionDefinition(fDef)
             newTheory = newTheory.withFunctionDefinition(fDef.mapBody(_.nnf))
         }
-        
-        problemState.copy(
-            theory = newTheory,
-            flags = problemState.flags.copy(haveRunNNF = true)
-        )
+
+        problemState
+        .withTheory(newTheory)
+        .withFlags(problemState.flags.copy(haveRunNNF = true))
     }
     
 

--- a/core/src/main/scala/fortress/transformers/QuantifierExpansionTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/QuantifierExpansionTransformer.scala
@@ -58,11 +58,7 @@ private[transformers] class QuantifierExpansionTransformer (useConstForDomElem: 
     
         val newTheory = Theory(newSig, newAxioms)
 
-//            println("Theory after quantifier expansion:")
-//            println(newTheory + "\n-----------------------------\n")
-
-        //ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapplyInterp, distinctConstants)
-        problemState.copy(theory = newTheory)
+        problemState.withTheory(newTheory)
     }
 
     /*

--- a/core/src/main/scala/fortress/transformers/Quantifiers/AntiPrenexTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Quantifiers/AntiPrenexTransformer.scala
@@ -17,10 +17,8 @@ object AntiPrenexTransformer extends ProblemStateTransformer {
         val theory = problemState.theory
         val newTheory = theory.mapAllTerms(_.antiPrenex)
 
-        problemState.copy(
-            theory = newTheory,
-            flags = problemState.flags,
-        )
+        problemState
+        .withTheory(newTheory)
     }
 
 

--- a/core/src/main/scala/fortress/transformers/Quantifiers/MaxAlphaRenamingTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Quantifiers/MaxAlphaRenamingTransformer.scala
@@ -9,11 +9,8 @@ import fortress.problemstate.ProblemState
   */
 object MaxAlphaRenamingTransformer extends ProblemStateTransformer {
 
-    override def apply(problemState: ProblemState): ProblemState = problemState.copy(
-        theory = problemState.theory.maxAlphaRenaming,
-        flags = problemState.flags.copy(haveRunMaxAlphaRenaming = true),
-    )
-
-
-
+    override def apply(problemState: ProblemState): ProblemState = 
+      problemState
+      .withTheory(problemState.theory.maxAlphaRenaming)
+      .withFlags(problemState.flags.copy(haveRunMaxAlphaRenaming = true))
 }

--- a/core/src/main/scala/fortress/transformers/Quantifiers/QuantifiersToDefnsTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Quantifiers/QuantifiersToDefnsTransformer.scala
@@ -11,61 +11,62 @@ object QuantifiersToDefnsTransformer extends ProblemStateTransformer {
 
 
 
-    override def apply(problemState: ProblemState): ProblemState = problemState match {
-        case ProblemState(theory, scopes, skc, skf, rangeRestricts, unapplyInterp, distinctConstants) =>
-            val forbiddenNames = scala.collection.mutable.Set[String]()
+    override def apply(problemState: ProblemState): ProblemState = {
+        val theory = problemState.theory
+        val forbiddenNames = scala.collection.mutable.Set[String]()
 
-            for(sort <- theory.sorts) {
-                forbiddenNames += sort.name
-            }
+        for(sort <- theory.sorts) {
+            forbiddenNames += sort.name
+        }
 
-            for(fdecl <- theory.functionDeclarations) {
-                forbiddenNames += fdecl.name
-            }
+        for(fdecl <- theory.functionDeclarations) {
+            forbiddenNames += fdecl.name
+        }
 
-            for(constant <- theory.constantDeclarations) {
-                forbiddenNames += constant.name
-            }
+        for(constant <- theory.constantDeclarations) {
+            forbiddenNames += constant.name
+        }
 
-            val nameGenerator = new IntSuffixNameGenerator(forbiddenNames.toSet, 0)
+        val nameGenerator = new IntSuffixNameGenerator(forbiddenNames.toSet, 0)
 
-            var resultTheory = theory.withoutAxioms
+        var resultTheory = theory.withoutAxioms
 
-            val closureFunctions = scala.collection.mutable.Set[FunctionDefinition]()
+        val closureFunctions = scala.collection.mutable.Set[FunctionDefinition]()
 
-            def updateResult(result: QuantifiersToDefinitions.Result): Unit = {
-                closureFunctions ++= result.definitions
-                resultTheory = resultTheory.withFunctionDefinitions(result.definitions)
-            }
+        def updateResult(result: QuantifiersToDefinitions.Result): Unit = {
+            closureFunctions ++= result.definitions
+            resultTheory = resultTheory.withFunctionDefinitions(result.definitions)
+        }
 
-            for (axiom <- theory.axioms) {
-                val result = QuantifiersToDefinitions(axiom, resultTheory.signature, nameGenerator)
+        for (axiom <- theory.axioms) {
+            val result = QuantifiersToDefinitions(axiom, resultTheory.signature, nameGenerator)
+            updateResult(result)
+            resultTheory = resultTheory.withAxiom(result.resultTerm)
+        }
+
+        for (cDef <- theory.constantDefinitions) {
+            resultTheory = resultTheory.withoutConstantDefinition(cDef)
+            val result = QuantifiersToDefinitions(cDef.body, resultTheory.signature, nameGenerator)
+            updateResult(result)
+            resultTheory = resultTheory.withConstantDefinition(
+                ConstantDefinition(cDef.avar, result.resultTerm))
+        }
+
+        for (fDef <- theory.functionDefinitions) {
+            // be careful not to apply to the definitions we generated!
+            if (!(closureFunctions contains fDef)) {
+                resultTheory = resultTheory.withoutFunctionDefinition(fDef)
+                val context = Context.empty(resultTheory.signature).stackPush(fDef.argSortedVar)
+                val result = QuantifiersToDefinitions(
+                    fDef.body, resultTheory.signature, nameGenerator, Some(context))
                 updateResult(result)
-                resultTheory = resultTheory.withAxiom(result.resultTerm)
+                resultTheory = resultTheory.withFunctionDefinition(
+                    fDef.copy(body = result.resultTerm))
             }
+        }
 
-            for (cDef <- theory.constantDefinitions) {
-                resultTheory = resultTheory.withoutConstantDefinition(cDef)
-                val result = QuantifiersToDefinitions(cDef.body, resultTheory.signature, nameGenerator)
-                updateResult(result)
-                resultTheory = resultTheory.withConstantDefinition(
-                    ConstantDefinition(cDef.avar, result.resultTerm))
-            }
-
-            for (fDef <- theory.functionDefinitions) {
-                // be careful not to apply to the definitions we generated!
-                if (!(closureFunctions contains fDef)) {
-                    resultTheory = resultTheory.withoutFunctionDefinition(fDef)
-                    val context = Context.empty(resultTheory.signature).stackPush(fDef.argSortedVar)
-                    val result = QuantifiersToDefinitions(
-                        fDef.body, resultTheory.signature, nameGenerator, Some(context))
-                    updateResult(result)
-                    resultTheory = resultTheory.withFunctionDefinition(
-                        fDef.copy(body = result.resultTerm))
-                }
-            }
-
-            ProblemState(resultTheory, scopes, skc, skf, rangeRestricts, unapplyInterp, distinctConstants)
+        problemState
+        .withTheory(resultTheory)
     }
 
 }

--- a/core/src/main/scala/fortress/transformers/Quantifiers/SkolemizeTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Quantifiers/SkolemizeTransformer.scala
@@ -132,13 +132,13 @@ object SkolemizeTransformer extends ProblemStateTransformer {
             distinctConstants
         )
         */
-        problemState.copy(
-            theory = resultTheory,
-            skolemConstants = problemState.skolemConstants ++ newSkolemConstants.toSet,
-            skolemFunctions = problemState.skolemFunctions ++ newSkolemFunctions.toSet,
-            unapplyInterp = unapply :: problemState.unapplyInterp,
-            flags = problemState.flags.copy(haveRunSkolemizer = true)
-        )
+
+        problemState
+        .withTheory(resultTheory)
+        .withSkolemConstants(problemState.skolemConstants ++ newSkolemConstants.toSet)
+        .withSkolemFunctions(problemState.skolemFunctions ++ newSkolemFunctions.toSet)
+        .withUnapplyInterp(unapply)
+        .withFlags(problemState.flags.copy(haveRunSkolemizer = true))
     }
     
     

--- a/core/src/main/scala/fortress/transformers/Quantifiers/SkolemizeTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Quantifiers/SkolemizeTransformer.scala
@@ -135,9 +135,9 @@ object SkolemizeTransformer extends ProblemStateTransformer {
 
         problemState
         .withTheory(resultTheory)
-        .withSkolemConstants(problemState.skolemConstants ++ newSkolemConstants.toSet)
-        .withSkolemFunctions(problemState.skolemFunctions ++ newSkolemFunctions.toSet)
-        .withUnapplyInterp(unapply)
+        .addSkolemConstants(newSkolemConstants.toSet)
+        .addSkolemFunctions(newSkolemFunctions.toSet)
+        .addUnapplyInterp(unapply)
         .withFlags(problemState.flags.copy(haveRunSkolemizer = true))
     }
     

--- a/core/src/main/scala/fortress/transformers/RangeFormulaTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/RangeFormulaTransformer.scala
@@ -86,11 +86,7 @@ private[transformers] class RangeFormulaTransformer (useConstForDomElem: Boolean
             .withAxioms(constantRangeConstraints)
             .withAxioms(functionRangeConstraints.toList)
 
-//            println("Theory after range formula generation:")
-//            println(newTheory + "\n-----------------------------\n")
-
-        //ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapplyInterp, distinctConstants)
-        problemState.copy(theory=newTheory)
+        problemState.withTheory(newTheory)
     }
     
     override def name: String = "Range Formula Transformer"

--- a/core/src/main/scala/fortress/transformers/Scopes/MaxUnboundedScopesTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Scopes/MaxUnboundedScopesTransformer.scala
@@ -14,10 +14,9 @@ object MaxUnboundedScopesTransformer extends ProblemStateTransformer {
 
         // keep only the fixed sorts
         // the sorts no longer in the scopes map become unbounded
-        val new_scopes = scopes.filter( _._2.isFixed() )  
+        val newScopes = scopes.filter({case (_, scope) => scope.isFixed()})  
         
-        problemState.copy(scopes = new_scopes)
-
+        problemState.withScopes(newScopes)
     }
 
 

--- a/core/src/main/scala/fortress/transformers/Scopes/ScopeNonExactPredicatesTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Scopes/ScopeNonExactPredicatesTransformer.scala
@@ -10,88 +10,80 @@ object  ScopeNonExactPredicatesTransformer extends ProblemStateTransformer {
 
     override def apply(problemState: ProblemState): ProblemState = {
 
-        //if (problemState.flags.containsNonExactScopes) {
-            problemState match {
-            case ProblemState(theory, scopes, skc, skf, rangeRestricts, unapplyInterp, flags) => {
+        val theory = problemState.theory
+        val scopes = problemState.scopes
 
-                val scopeNonExactPreds = for {
-                    sort <- theory.sorts
-                    if scopes.contains(sort) && !scopes(sort).isExact
-                } yield {
-                    val predName = ScopeNonExactPredicates.nonExactScopePred(sort)  // " __@Pred_{sort.name} "
-                    val predDecl = FuncDecl(predName, sort, BoolSort)
-                    predDecl
+        val scopeNonExactPreds = for {
+            sort <- theory.sorts
+            if scopes.contains(sort) && !scopes(sort).isExact
+        } yield {
+            val predName = ScopeNonExactPredicates.nonExactScopePred(sort)  // " __@Pred_{sort.name} "
+            val predDecl = FuncDecl(predName, sort, BoolSort)
+            predDecl
+        }
+
+        // Have to say the subtypes are nonempty
+        /*
+        NAD: removed these axioms to allow the predicate to not be satisfied by
+                any elements and therefore allow the sort to be empty for a non-exact scope
+                2023-06-26
+                These were added likely for comparison with nondistinct constants method,
+                which requires there to be at least one value.
+                
+        val antiVacuityAxioms = for {
+            sort <- theory.sorts
+            if scopes.contains(sort) && !scopes(sort).isExact
+        } yield {
+            Exists(Var("x") of sort, App(ScopeNonExactPredicates.nonExactScopePred(sort), Var("x")))
+        }
+        */
+        // Constants and functions must have ranges in the subtypes
+        val constantAxioms = for (av <- theory.constantDeclarations if scopes.contains(av.sort) && !scopes(av.sort).isExact ) yield App(ScopeNonExactPredicates.nonExactScopePred(av.sort), av.variable)
+
+        val functionAxioms = for {
+            fdecl <- theory.functionDeclarations
+            if scopes.contains(fdecl.resultSort) && !scopes(fdecl.resultSort).isExact
+        } yield {
+            val argsAnnotated = fdecl.argSorts.zipWithIndex.map { case (sort, index) => Var(s"x_${sort}_${index}") of sort }
+
+            // For each arg with a non-exact scope, add a hypothesis that the arg is in its sort
+            val guards = argsAnnotated
+                .filter { arg => !scopes(arg.sort).isExact }
+                .map { arg => App(ScopeNonExactPredicates.nonExactScopePred(arg.sort), arg.variable) }
+
+            // Suppose f: AxB->C and all are non-exact. Generate the following axiom:
+            // forall a: A, b: B . inA(a) && inB(b) => inC(f(a,b))
+            val outputPred = ScopeNonExactPredicates.nonExactScopePred(fdecl.resultSort)
+            Forall(argsAnnotated,
+                Implication(And.smart(guards),
+                    App(outputPred, App(fdecl.name, argsAnnotated.map(_.variable)))))
+        }
+
+        val resultTheory = theory
+            .withFunctionDeclarations(scopeNonExactPreds)
+            .someAxioms(ScopeNonExactPredicates.addBoundsPredicates, scopes)
+            // NAD see note above
+            //.withAxioms(antiVacuityAxioms)
+            .withAxioms(constantAxioms)
+            .withAxioms(functionAxioms)
+
+        val unapply: Interpretation => Interpretation = {
+            interp => {
+                var resultInterp = interp
+                val sortInterp: Map[Sort, Seq[Value]] = interp.sortInterpretations
+                for(pred <- scopeNonExactPreds) {
+                    val sort: Sort = pred.argSorts.head
+                    val Interp: Seq[Value] = sortInterp(sort).filter(value => {
+                        interp.getFunctionValue(pred.name, Seq(value)) == Top
+                    })
+                    resultInterp = resultInterp.updateSortInterpretations(sort, Interp)
                 }
-
-                // Have to say the subtypes are nonempty
-                /*
-                NAD: removed these axioms to allow the predicate to not be satisfied by
-                     any elements and therefore allow the sort to be empty for a non-exact scope
-                     2023-06-26
-                     These were added likely for comparison with nondistinct constants method,
-                     which requires there to be at least one value.
-                     
-                val antiVacuityAxioms = for {
-                    sort <- theory.sorts
-                    if scopes.contains(sort) && !scopes(sort).isExact
-                } yield {
-                    Exists(Var("x") of sort, App(ScopeNonExactPredicates.nonExactScopePred(sort), Var("x")))
-                }
-                */
-                // Constants and functions must have ranges in the subtypes
-                val constantAxioms = for (av <- theory.constantDeclarations if scopes.contains(av.sort) && !scopes(av.sort).isExact ) yield App(ScopeNonExactPredicates.nonExactScopePred(av.sort), av.variable)
-
-                val functionAxioms = for {
-                    fdecl <- theory.functionDeclarations
-                    if scopes.contains(fdecl.resultSort) && !scopes(fdecl.resultSort).isExact
-                } yield {
-                    val argsAnnotated = fdecl.argSorts.zipWithIndex.map { case (sort, index) => Var(s"x_${sort}_${index}") of sort }
-
-                    // For each arg with a non-exact scope, add a hypothesis that the arg is in its sort
-                    val guards = argsAnnotated
-                        .filter { arg => !scopes(arg.sort).isExact }
-                        .map { arg => App(ScopeNonExactPredicates.nonExactScopePred(arg.sort), arg.variable) }
-
-                    // Suppose f: AxB->C and all are non-exact. Generate the following axiom:
-                    // forall a: A, b: B . inA(a) && inB(b) => inC(f(a,b))
-                    val outputPred = ScopeNonExactPredicates.nonExactScopePred(fdecl.resultSort)
-                    Forall(argsAnnotated,
-                        Implication(And.smart(guards),
-                            App(outputPred, App(fdecl.name, argsAnnotated.map(_.variable)))))
-                }
-
-                val resultTheory = theory
-                  .withFunctionDeclarations(scopeNonExactPreds)
-                  .someAxioms(ScopeNonExactPredicates.addBoundsPredicates, scopes)
-                  // NAD see note above
-                  //.withAxioms(antiVacuityAxioms)
-                  .withAxioms(constantAxioms)
-                  .withAxioms(functionAxioms)
-
-                val unapply: Interpretation => Interpretation = {
-                    interp => {
-                        var resultInterp = interp
-                        val sortInterp: Map[Sort, Seq[Value]] = interp.sortInterpretations
-                        for(pred <- scopeNonExactPreds) {
-                            val sort: Sort = pred.argSorts.head
-                            val Interp: Seq[Value] = sortInterp(sort).filter(value => {
-                                interp.getFunctionValue(pred.name, Seq(value)) == Top
-                            })
-                            resultInterp = resultInterp.updateSortInterpretations(sort, Interp)
-                        }
-                        resultInterp.withoutFunctions(scopeNonExactPreds)
-                    }
-                }
-
-                ProblemState(
-                    resultTheory,
-                    scopes, skc,
-                    skf,
-                    rangeRestricts,
-                    unapply :: unapplyInterp,
-                    flags
-                )
-            }}
+                resultInterp.withoutFunctions(scopeNonExactPreds)
+            }
+        }              
+    
+        problemState.withTheory(resultTheory)
+        .withUnapplyInterp(unapply)
         /*
         } else {
             return problemState

--- a/core/src/main/scala/fortress/transformers/Scopes/ScopeNonExactPredicatesTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Scopes/ScopeNonExactPredicatesTransformer.scala
@@ -83,7 +83,7 @@ object  ScopeNonExactPredicatesTransformer extends ProblemStateTransformer {
         }              
     
         problemState.withTheory(resultTheory)
-        .withUnapplyInterp(unapply)
+        .addUnapplyInterp(unapply)
         /*
         } else {
             return problemState

--- a/core/src/main/scala/fortress/transformers/Simplify/SimplifyConstantsNotDistinctTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Simplify/SimplifyConstantsNotDistinctTransformer.scala
@@ -14,13 +14,8 @@ import fortress.problemstate.ProblemState
   * */
 
 object SimplifyConstantsNotDistinctTransformer extends ProblemStateTransformer {
-    
-    override def apply(problemState: ProblemState): ProblemState =  {
-      problemState.copy(
-        theory = problemState.theory.mapAllTerms(SimplifierConstantsNotDistinct
-          .simplify)
-      )
-    }
-    
-
+    override def apply(problemState: ProblemState): ProblemState =
+        problemState.withTheory(
+            problemState.theory.mapAllTerms(SimplifierConstantsNotDistinct.simplify)
+        )
 }

--- a/core/src/main/scala/fortress/transformers/Simplify/SimplifyLearnedLiteralsTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Simplify/SimplifyLearnedLiteralsTransformer.scala
@@ -43,9 +43,7 @@ object SimplifyLearnedLiteralsTransformer extends ProblemStateTransformer {
 
 
         // Theory(theory.signature, newAxioms)
-        problemState.copy(
-            theory = Theory(theory.signature, newAxioms),
-        )
+        problemState.withTheory(Theory(theory.signature, newAxioms))
     }
 
 

--- a/core/src/main/scala/fortress/transformers/Simplify/SimplifyTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Simplify/SimplifyTransformer.scala
@@ -10,10 +10,9 @@ object SimplifyTransformer extends ProblemStateTransformer {
 
     override def apply(problemState: ProblemState): ProblemState =  {
         val newTheory = problemState.theory.mapAllTerms(_.simplify)
-        problemState.copy(
-            theory = newTheory,
-            flags = problemState.flags.copy(trivialResult = newTheory.checkTrivial),
-        )
+        problemState
+        .withTheory(newTheory)
+        .withFlags(problemState.flags.copy(trivialResult = newTheory.checkTrivial))
     }
 
 

--- a/core/src/main/scala/fortress/transformers/Simplify/SimplifyWithRangeTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Simplify/SimplifyWithRangeTransformer.scala
@@ -15,7 +15,7 @@ object SimplifyWithRangeTransformer extends ProblemStateTransformer {
         val newTheory = theory.mapAllTerms(_.simplifyWithRange(rangeRestricts))
         // val newTheory = theory.mapAxioms(_.simplify)
         // ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapplyInterp, distinctConstants)
-        problemState.copy(theory=newTheory)
+        problemState.withTheory(newTheory)
     }
     
 

--- a/core/src/main/scala/fortress/transformers/Simplify/SimplifyWithScalarQuantifiersTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Simplify/SimplifyWithScalarQuantifiersTransformer.scala
@@ -27,9 +27,7 @@ object SimplifyWithScalarQuantifiersTransformer extends ProblemStateTransformer 
             .mapAllTerms(ScalarQuantifierSimplifier.simplify)
             .mapAllTerms(_.simplify)  // clean up anything introduced
 
-        problemState.copy(
-            theory = newTheory
-        )
+        problemState.withTheory(newTheory)
     }
 
 

--- a/core/src/main/scala/fortress/transformers/Simplify/SplitConjunctionTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Simplify/SplitConjunctionTransformer.scala
@@ -18,9 +18,7 @@ object SplitConjunctionTransformer extends ProblemStateTransformer {
         theory.axioms.map(splitConjunctions)
     	val newTheory = Theory(theory.signature, newAxioms)
 
-        problemState.copy(
-            theory = newTheory
-        )
+        problemState.withTheory(newTheory)
     }
     
 

--- a/core/src/main/scala/fortress/transformers/SortInferenceTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/SortInferenceTransformer.scala
@@ -25,14 +25,12 @@ object SortInferenceTransformer extends ProblemStateTransformer {
         }
         val unapply: Interpretation => Interpretation = _.applySortSubstitution(sortSubstitution)
 
-        // ProblemState(generalTheory, newScopes.toMap, skc map (sortSubstitution(_)), skf map (sortSubstitution(_)), rangeRestricts, unapply :: unapplyInterp, distinctConstants)
-        problemState.copy(
-            theory = generalTheory,
-            scopes = newScopes.toMap,
-            skolemConstants = problemState.skolemConstants map (sortSubstitution(_)),
-            skolemFunctions = problemState.skolemFunctions map (sortSubstitution(_)),
-            unapplyInterp = unapply :: problemState.unapplyInterp,
-        )
+        problemState
+        .withTheory(generalTheory)
+        .withScopes(newScopes.toMap)
+        .withSkolemConstants(problemState.skolemConstants map (sortSubstitution(_)))
+        .withSkolemFunctions(problemState.skolemFunctions map (sortSubstitution(_)))
+        .withUnapplyInterp(unapply)
     }
     
 

--- a/core/src/main/scala/fortress/transformers/SortInferenceTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/SortInferenceTransformer.scala
@@ -30,7 +30,7 @@ object SortInferenceTransformer extends ProblemStateTransformer {
         .withScopes(newScopes.toMap)
         .withSkolemConstants(problemState.skolemConstants map (sortSubstitution(_)))
         .withSkolemFunctions(problemState.skolemFunctions map (sortSubstitution(_)))
-        .withUnapplyInterp(unapply)
+        .addUnapplyInterp(unapply)
     }
     
 

--- a/core/src/main/scala/fortress/transformers/Symmetry/SymmetryBreakingTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Symmetry/SymmetryBreakingTransformer.scala
@@ -62,7 +62,7 @@ class SymmetryBreakingTransformer(
     }
 
     def apply(problemState: ProblemState): ProblemState = problemState match {
-        case ProblemState(theory, scopes, skc, skf, rangeRestricts, unapplyInterp, distinctConstants) => {
+        case ProblemState(theory, scopes, skc, skf, rangeRestricts, unapplyInterp, flags) => {
 
             val (newDecls, newConstraints, newRangeRestrictions) = if(options.sortInference) {
                 // Perform sort inference first
@@ -92,7 +92,9 @@ class SymmetryBreakingTransformer(
 
             // Add symmetry breaking function declarations, constraints, and range restrictions
             val newTheory = theory.withFunctionDeclarations(newDecls).withAxioms(newConstraints)
-            ProblemState(newTheory, scopes, skc, skf, rangeRestricts union newRangeRestrictions, unapplyInterp, distinctConstants)
+            problemState
+            .withTheory(newTheory)
+            .withRangeRestrictions(rangeRestricts union newRangeRestrictions)
         }
     }
 

--- a/core/src/main/scala/fortress/transformers/Symmetry/SymmetryBreakingTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Symmetry/SymmetryBreakingTransformer.scala
@@ -94,7 +94,7 @@ class SymmetryBreakingTransformer(
             val newTheory = theory.withFunctionDeclarations(newDecls).withAxioms(newConstraints)
             problemState
             .withTheory(newTheory)
-            .withRangeRestrictions(rangeRestricts union newRangeRestrictions)
+            .addRangeRestrictions(newRangeRestrictions)
         }
     }
 

--- a/core/src/main/scala/fortress/transformers/Symmetry/SymmetryBreakingTransformer_MostUsed.scala
+++ b/core/src/main/scala/fortress/transformers/Symmetry/SymmetryBreakingTransformer_MostUsed.scala
@@ -73,10 +73,9 @@ class SymmetryBreakingTransformer_MostUsed(
         val newTheory = theory.withFunctionDeclarations(breaker.declarations).withAxioms(breaker.constraints)
 
         // ProblemState(newTheory, scopes, skc, skf, rangeRestricts union breaker.rangeRestrictions.toSet, unapplyInterp, distinctConstants)
-        problemState.copy(
-            theory = newTheory,
-            rangeRestrictions = problemState.rangeRestrictions union breaker.rangeRestrictions.toSet,
-        )
+        problemState
+        .withTheory(newTheory)
+        .withRangeRestrictions(problemState.rangeRestrictions union breaker.rangeRestrictions.toSet)
     }
     /*
     val name: String = s"Symmetry Breaking Transformer Most Used (${selectionHeuristicFactory.name})"

--- a/core/src/main/scala/fortress/transformers/Symmetry/SymmetryBreakingTransformer_MostUsed.scala
+++ b/core/src/main/scala/fortress/transformers/Symmetry/SymmetryBreakingTransformer_MostUsed.scala
@@ -75,7 +75,7 @@ class SymmetryBreakingTransformer_MostUsed(
         // ProblemState(newTheory, scopes, skc, skf, rangeRestricts union breaker.rangeRestrictions.toSet, unapplyInterp, distinctConstants)
         problemState
         .withTheory(newTheory)
-        .withRangeRestrictions(problemState.rangeRestrictions union breaker.rangeRestrictions.toSet)
+        .addRangeRestrictions(breaker.rangeRestrictions.toSet)
     }
     /*
     val name: String = s"Symmetry Breaking Transformer Most Used (${selectionHeuristicFactory.name})"

--- a/core/src/main/scala/fortress/transformers/TheoryTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/TheoryTransformer.scala
@@ -19,8 +19,8 @@ object TheoryTransformer {
     implicit def asProblemStateTransformer(theoryTransformer: TheoryTransformer): ProblemStateTransformer = {
         object asPST extends ProblemStateTransformer {
             override def apply(problemState: ProblemState): ProblemState = {
-                problemState.copy(
-                    theory = theoryTransformer(problemState.theory, problemState.flags)
+                problemState.withTheory(
+                    theoryTransformer(problemState.theory, problemState.flags)
                 )
             }
             

--- a/core/src/main/scala/fortress/transformers/TypecheckSanitizeTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/TypecheckSanitizeTransformer.scala
@@ -48,9 +48,10 @@ object TypecheckSanitizeTransformer extends ProblemStateTransformer {
                         fDef.resultSort)))
         }
 
-        problemState.copy(
-            theory = newTheory,
-            flags = problemState.flags.copy(
+        problemState
+        .withTheory(newTheory)
+        .withFlags(
+            problemState.flags.copy(
                 containsItes = containsItes,
                 containsExists = containsExists
             )

--- a/core/src/main/scala/fortress/transformers/enumerateFiniteValues/DEsToConstantsTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/enumerateFiniteValues/DEsToConstantsTransformer.scala
@@ -60,10 +60,9 @@ class DEsToConstantsTransformer(constantsDistinct:Boolean = true) extends Proble
             }
             else Theory(newSig, convertedAxioms)
         
-        problemState.copy(
-            theory = newTheory,
-            flags = problemState.flags.copy(distinctConstants = constantsDistinct)
-        )
+        problemState
+        .withTheory(newTheory)
+        .withFlags(problemState.flags.copy(distinctConstants = constantsDistinct))
     }
 }
 

--- a/core/src/main/scala/fortress/transformers/enumerateFiniteValues/DEsToEnumsTransformer.scala
+++ b/core/src/main/scala/fortress/transformers/enumerateFiniteValues/DEsToEnumsTransformer.scala
@@ -50,10 +50,9 @@ object DEsToEnumsTransformer extends ProblemStateTransformer {
 
 
         //ProblemState(newTheory, scopes, skc, skf, rangeRestricts, unapplyInterp, distinctConstants = false)
-        problemState.copy(
-            theory = newTheory,
-            flags = problemState.flags.copy(distinctConstants = false)
-        )
+        problemState
+        .withTheory(newTheory)
+        .withFlags(problemState.flags.copy(distinctConstants = false))
     }
 
 


### PR DESCRIPTION
This should switch transformers to using `withX()` operations. Doing this triggered some of our internal checks that were ignored previously. Transformers pass all tests, but it's a lot of code changed so I would appreciate a review.