### PR TITLE
Fix quantified variables leaking through UpInfo

### DIFF
--- a/core/src/main/scala/fortress/transformers/Integers/IntOPFITransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Integers/IntOPFITransformer.scala
@@ -28,7 +28,7 @@ object IntOPFITransformer extends ProblemStateTransformer {
         // We don't want to replicate existing functions or variables or constants
         val forbiddenNames: Set[String] = (
             problemState.theory.constantDeclarations.map(_.name) union problemState.theory.functionDeclarations.map(_.name) union
-            problemState.theory.functionDefinitions.map(_.name)
+            problemState.theory.functionDefinitions.map(_.name) union problemState.theory.constantDefinitions.map(_.name)
         ).toSet
         val varNameGenerator: NameGenerator = new IntSuffixNameGenerator(forbiddenNames, 0)
         // sorts have their own exclusive names
@@ -202,7 +202,7 @@ object IntOPFITransformer extends ProblemStateTransformer {
                     .withOtherVars(otherVars)
 
                 val (newBody, upInfo) = transform(body, newDown)
-                (Exists(newVars ++ otherVars, newBody), upInfo.excludingVars(newVars.map(_.variable)))
+                (Exists(newVars ++ otherVars, newBody), upInfo.excludingVars((newVars ++ otherVars).map(_.variable)))
             }
             case Forall(vars, body) => {
                 // Change integers to oaf ints
@@ -217,7 +217,7 @@ object IntOPFITransformer extends ProblemStateTransformer {
                     .withOtherVars(otherVars)
 
                 val (newBody, upInfo) = transform(body, newDown)
-                (Forall(newVars ++ otherVars, newBody), upInfo.excludingVars(newVars.map(_.variable)))
+                (Forall(newVars ++ otherVars, newBody), upInfo.excludingVars((newVars ++ otherVars).map(_.variable)))
             }
 
             case Var(varName) => {


### PR DESCRIPTION
I encountered an issue where quantified variables would leak past their quantifiers through OPFI's UpInfo. I think this should fix it but would appreciate a review @otzzila.

Also made sure that OPFI doesn't duplicate the names of constant definitions.