### PR TITLE
Set model.user_functions=false in Z3

### DIFF
--- a/core/src/main/scala/fortress/solvers/Z3NonIncCliSolver.scala
+++ b/core/src/main/scala/fortress/solvers/Z3NonIncCliSolver.scala
@@ -3,7 +3,7 @@ package fortress.solvers
 import fortress.util._
 
 class Z3NonIncCliSolver extends SMTLIBCliSolver {
-    override def processArgs: Seq[String] = Seq("z3", "-smt2", "-in")
+    override def processArgs: Seq[String] = Seq("z3", "model.user_functions=false", "-smt2", "-in")
 
     override def timeoutArg(timeoutMillis: Milliseconds): String = "-t:" + timeoutMillis.value
 }


### PR DESCRIPTION
This option tells Z3 not to generate definitions for user-defined (interpreted) functions and constants in response to (get-model). This was causing an issue with the new Portus ExprDefns optimization because Z3 was parrotting very large definitions and causing the SMTLIB parser to choke.