### PR TITLE
Properly handle shadowing in MaxAlphaRenaming

### DIFF
--- a/core/src/test/scala/operations/MaxAlphaRenamingTest.scala
+++ b/core/src/test/scala/operations/MaxAlphaRenamingTest.scala
@@ -1,0 +1,66 @@
+import fortress.msfol._
+import fortress.operations.MaxAlphaRenaming
+
+class MaxAlphaRenamingTest extends UnitSuite {
+
+    test("rename with bound variable shadowing bound variable") {
+        val x = Var("x")
+        val sort = SortConst("Sort")
+        val term = Forall(x of sort, And(Exists(x of sort, App("f", x)), App("g", x)))
+        val theory = Theory.empty
+            .withSort(sort)
+            .withAxiom(term)
+
+        val x0 = Var("x_0")
+        val x1 = Var("x_1")
+        val expectedTerm = Forall(x0 of sort, And(Exists(x1 of sort, App("f", x1)), App("g", x0)))
+
+        val resultTheory = MaxAlphaRenaming.rename(theory)
+        resultTheory.axioms should contain(expectedTerm)
+    }
+
+    test("rename with bound variable shadowing constant") {
+        val x = Var("x")
+        val sort = SortConst("Sort")
+        val term = Forall(x of sort, App("f", x))
+        val theory = Theory.empty
+            .withSort(sort)
+            .withConstantDeclaration(x of sort)
+            .withAxiom(term)
+            .withAxiom(App("g", x)) // use the constant
+
+        val x0 = Var("x_0")
+        val expectedTerm = Forall(x0 of sort, App("f", x0))
+        val expectedTheory = Theory.empty
+            .withSort(sort)
+            .withConstantDeclaration(x of sort)
+            .withAxiom(expectedTerm)
+            .withAxiom(App("g", x))
+
+        val resultTheory = MaxAlphaRenaming.rename(theory)
+        resultTheory should equal(expectedTheory)
+    }
+
+    test("rename with function definition param shadowing constant") {
+        val x = Var("x")
+        val sort = SortConst("Sort")
+        val funcDefn = FunctionDefinition("f", Seq(x of sort), sort, x)
+        val theory = Theory.empty
+            .withSort(sort)
+            .withConstantDeclaration(x of sort)
+            .withFunctionDefinition(funcDefn)
+            .withAxiom(App("f", x))
+
+        val x0 = Var("x_0")
+        val expectedFuncDefn = FunctionDefinition("f", Seq(x0 of sort), sort, x0)
+        val expectedTheory = Theory.empty
+            .withSort(sort)
+            .withConstantDeclaration(x of sort)
+            .withFunctionDefinition(expectedFuncDefn)
+            .withAxiom(App("f", x))
+
+        val resultTheory = MaxAlphaRenaming.rename(theory)
+        resultTheory should equal(expectedTheory)
+    }
+
+}

--- a/core/src/test/scala/transformers/IntOPFITransformerTests.scala
+++ b/core/src/test/scala/transformers/IntOPFITransformerTests.scala
@@ -233,12 +233,15 @@ class IntOPFITransformerTests extends UnitSuite {
     }
 
     test("multiply in range"){
-        // exists x: 2x < 0 | !(2x < 0)
+        // exists x: x != 0 & (2x < 0 | !(2x < 0))
         // Should only give values that when doubled are still in range
-        val axiom = Or(
+        val axiom = And(
+            Not(Eq(x, IntegerLiteral(0))),
+            Or(
                 Term.mkLT(Term.mkMult(IntegerLiteral(2), x), IntegerLiteral(0)), // 2x < 0
                 Not(Term.mkLT(Term.mkMult(IntegerLiteral(2), x), IntegerLiteral(0)))
-            )
+            ),
+        )
 
 
         val scopes: Map[Sort, Scope] = Map(IntSort -> ExactScope(4, true))

--- a/core/src/test/scala/transformers/OPFIntsTransformerTest.scala
+++ b/core/src/test/scala/transformers/OPFIntsTransformerTest.scala
@@ -245,12 +245,15 @@ class OPFIntsTransformerTest extends UnitSuite {
     }
 
     test("multiply in range"){
-        // exists x: 2x < 0 | !(2x < 0)
+        // exists x: x != 0 & (2x < 0 | !(2x < 0))
         // Should only give values that when doubled are still in range
-        val axiom = Or(
+        val axiom = And(
+            Not(Eq(x, IntegerLiteral(0))),
+            Or(
                 Term.mkLT(Term.mkMult(IntegerLiteral(2), x), IntegerLiteral(0)), // 2x < 0
                 Not(Term.mkLT(Term.mkMult(IntegerLiteral(2), x), IntegerLiteral(0)))
-            )
+            ),
+        )
 
 
         val scopes: Map[Sort, Scope] = Map(IntSort -> ExactScope(4, true))


### PR DESCRIPTION
MaxAlphaRenaming completely failed to handle variable shadowing before (oops!). Now it's handled properly.

Once this was fixed I was still getting an error in the OPFI test that was failing because the solution found had `x = 0`, which seemed to be a valid solution even though the intention was for the only allowable solution to be `x = -1`. So I modified the test to explicitly disallow `x = 0`.