### PR TITLE
Fix OPFI typechecking for ITE

### DIFF
--- a/core/src/main/scala/fortress/transformers/Integers/IntOPFITransformer.scala
+++ b/core/src/main/scala/fortress/transformers/Integers/IntOPFITransformer.scala
@@ -401,7 +401,7 @@ object IntOPFITransformer extends ProblemStateTransformer {
                 val transformedITE = IfThenElse(transformedCondition, transformedIfTrue, transformedIfFalse)
 
                 // predicate needs to be wrapped with the conditional's ability to overflow (the branches should already be handled)
-                val resultSort = ifTrue.typeCheck(down.typeCheckSig(newSignature, newSort)).sort
+                val resultSort = transformedIfTrue.typeCheck(down.typeCheckSig(newSignature, newSort)).sort
                 if (resultSort == BoolSort){
                     val guardedITE = newUp.overflowPredicate(transformedITE, down.polarity, isInBounds.name)
                     (guardedITE, newUp)


### PR DESCRIPTION
The Chord model with the current version of Portus (on the `portus-more-support` branch) and the current Fortress master was failing Fortress typechecking due to an Int/OPFIInt clash on this line. This seems to fix it.